### PR TITLE
User list; bolt transactions

### DIFF
--- a/api/auth.go
+++ b/api/auth.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"fmt"
 	"net/http"
 )
 
@@ -21,21 +20,6 @@ func NewAuthHandler(db *Db, key NewTokener) Auth {
 	return Auth{db: db, key: key}
 }
 
-func (auth Auth) validLogin(email, password string) (bool, error) {
-	users, err := auth.db.Users()
-	if err != nil {
-		return false, fmt.Errorf("error retrieving user list: %v", err)
-	}
-
-	for _, user := range users {
-		if user.Email == email && user.Pass == password {
-			return true, nil
-		}
-	}
-
-	return false, nil
-}
-
 // ServeHTTP serves requests to authenticate.
 func (auth Auth) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	if req.Method != http.MethodPost {
@@ -46,7 +30,7 @@ func (auth Auth) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	email := req.FormValue("email")
 	password := req.FormValue("password")
 
-	if valid, err := auth.validLogin(email, password); err != nil {
+	if valid, err := validLogin(auth.db.store, email, password); err != nil {
 		http.Error(res, err.Error(), http.StatusInternalServerError)
 		return
 	} else if !valid {

--- a/api/auth.go
+++ b/api/auth.go
@@ -3,13 +3,11 @@ package api
 import (
 	"fmt"
 	"net/http"
-
-	"github.com/simpleiot/simpleiot/db"
 )
 
 // Auth handles user authentication requests.
 type Auth struct {
-	db  *db.Db
+	db  *Db
 	key NewTokener
 }
 
@@ -19,7 +17,7 @@ type NewTokener interface {
 }
 
 // NewAuthHandler returns a new authentication handler using the given key.
-func NewAuthHandler(db *db.Db, key NewTokener) Auth {
+func NewAuthHandler(db *Db, key NewTokener) Auth {
 	return Auth{db: db, key: key}
 }
 

--- a/api/db.go
+++ b/api/db.go
@@ -3,7 +3,6 @@ package api
 import (
 	"fmt"
 	"path"
-	"sync"
 
 	"github.com/simpleiot/simpleiot/data"
 	"github.com/timshannon/bolthold"
@@ -16,7 +15,6 @@ import (
 // handle multiple Db backends.
 type Db struct {
 	store *bolthold.Store
-	lock  sync.RWMutex
 }
 
 // NewDb creates a new Db instance for the app
@@ -33,15 +31,11 @@ func NewDb(dataDir string) (*Db, error) {
 
 // DeviceUpdate updates a devices state in the database
 func (db *Db) DeviceUpdate(device data.Device) error {
-	db.lock.Lock()
-	defer db.lock.Unlock()
 	return db.store.Upsert(device.ID, &device)
 }
 
 // DeviceUpdateConfig updates the config for a particular device
 func (db *Db) DeviceUpdateConfig(id string, config data.DeviceConfig) error {
-	db.lock.Lock()
-	defer db.lock.Unlock()
 	var dev data.Device
 	err := db.store.Get(id, &dev)
 
@@ -56,8 +50,6 @@ func (db *Db) DeviceUpdateConfig(id string, config data.DeviceConfig) error {
 
 // DeviceSample processes a sample for a particular device
 func (db *Db) DeviceSample(id string, sample data.Sample) error {
-	db.lock.Lock()
-	defer db.lock.Unlock()
 	var dev data.Device
 	err := db.store.Get(id, &dev)
 
@@ -81,24 +73,18 @@ func (db *Db) DeviceSample(id string, sample data.Sample) error {
 
 // Device returns data for a particular device
 func (db *Db) Device(id string) (ret data.Device, err error) {
-	db.lock.RLock()
-	defer db.lock.RUnlock()
 	err = db.store.Get(id, &ret)
 	return
 }
 
 // DeviceDelete deletes a device from the database
 func (db *Db) DeviceDelete(id string) error {
-	db.lock.Lock()
-	defer db.lock.Unlock()
 	return db.store.Delete(id, data.Device{})
 }
 
 // DeviceSetVersion sets a cmd for a device, and sets the
 // CmdPending flag in the device structure.
 func (db *Db) DeviceSetVersion(id string, ver data.DeviceVersion) error {
-	db.lock.Lock()
-	defer db.lock.Unlock()
 
 	var dev data.Device
 	err := db.store.Get(id, &dev)
@@ -113,8 +99,6 @@ func (db *Db) DeviceSetVersion(id string, ver data.DeviceVersion) error {
 // DeviceSetCmd sets a cmd for a device, and sets the
 // CmdPending flag in the device structure.
 func (db *Db) DeviceSetCmd(cmd data.DeviceCmd) error {
-	db.lock.Lock()
-	defer db.lock.Unlock()
 
 	err := db.store.Upsert(cmd.ID, &cmd)
 	if err != nil {
@@ -149,8 +133,6 @@ func (db *Db) DeviceGetCmd(id string) (data.DeviceCmd, error) {
 
 	if cmd.Cmd != "" {
 		// a device has fetched a command, delete it
-		db.lock.Lock()
-		defer db.lock.Unlock()
 		err := db.store.Delete(id, data.DeviceCmd{})
 		if err != nil {
 			return cmd, err
@@ -200,8 +182,6 @@ func (db *Db) User(id string) (user *data.User, err error) {
 
 // UserUpsert modifies or creates a user.
 func (db *Db) UserUpsert(id string, user data.User) error {
-	db.lock.Lock()
-	defer db.lock.Unlock()
 	return db.store.Upsert(user.ID, &user)
 }
 

--- a/api/db.go
+++ b/api/db.go
@@ -36,16 +36,16 @@ func (db *Db) DeviceUpdate(device data.Device) error {
 
 // deviceUpdateConfig updates the config for a particular device
 func deviceUpdateConfig(store *bolthold.Store, id string, config data.DeviceConfig) error {
-	var dev data.Device
-	err := store.Get(id, &dev)
+	return store.Bolt().Update(func(tx *bolt.Tx) error {
+		var dev data.Device
+		if err := store.TxGet(tx, id, &dev); err != nil {
+			return err
+		}
 
-	if err == bolthold.ErrNotFound {
-		return err
-	}
+		dev.Config = config
 
-	dev.Config = config
-
-	return store.Update(id, dev)
+		return store.TxUpdate(tx, id, dev)
+	})
 }
 
 // DeviceSample processes a sample for a particular device

--- a/api/db.go
+++ b/api/db.go
@@ -34,10 +34,10 @@ func (db *Db) DeviceUpdate(device data.Device) error {
 	return db.store.Upsert(device.ID, &device)
 }
 
-// DeviceUpdateConfig updates the config for a particular device
-func (db *Db) DeviceUpdateConfig(id string, config data.DeviceConfig) error {
+// deviceUpdateConfig updates the config for a particular device
+func deviceUpdateConfig(store *bolthold.Store, id string, config data.DeviceConfig) error {
 	var dev data.Device
-	err := db.store.Get(id, &dev)
+	err := store.Get(id, &dev)
 
 	if err == bolthold.ErrNotFound {
 		return err
@@ -45,7 +45,7 @@ func (db *Db) DeviceUpdateConfig(id string, config data.DeviceConfig) error {
 
 	dev.Config = config
 
-	return db.store.Update(id, dev)
+	return store.Update(id, dev)
 }
 
 // DeviceSample processes a sample for a particular device

--- a/api/devices.go
+++ b/api/devices.go
@@ -27,7 +27,7 @@ func (h *Devices) processCmd(res http.ResponseWriter, req *http.Request, id stri
 	// set ID in case it is not set in API call
 	c.ID = id
 
-	err = h.db.DeviceSetCmd(c)
+	err = deviceSetCmd(h.db.store, c)
 	if err != nil {
 		http.Error(res, err.Error(), http.StatusInternalServerError)
 		return
@@ -46,7 +46,7 @@ func (h *Devices) processVersion(res http.ResponseWriter, req *http.Request, id 
 		return
 	}
 
-	err = h.db.DeviceSetVersion(id, v)
+	err = deviceSetVersion(h.db.store, id, v)
 	if err != nil {
 		http.Error(res, err.Error(), http.StatusInternalServerError)
 		return
@@ -131,7 +131,7 @@ func (h *Devices) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	case "cmd":
 		if req.Method == http.MethodGet {
 			// Get is done by devices
-			cmd, err := h.db.DeviceGetCmd(id)
+			cmd, err := deviceGetCmd(h.db.store, id)
 			if err != nil {
 				http.Error(res, err.Error(), http.StatusInternalServerError)
 			}
@@ -168,7 +168,7 @@ func (h *Devices) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 		if id == "" {
 			switch req.Method {
 			case http.MethodGet:
-				devices, err := h.db.Devices()
+				devices, err := devices(h.db.store)
 				if err != nil {
 					http.Error(res, err.Error(), http.StatusNotFound)
 					return
@@ -181,7 +181,7 @@ func (h *Devices) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 		} else {
 			switch req.Method {
 			case http.MethodGet:
-				device, err := h.db.Device(id)
+				device, err := device(h.db.store, id)
 				if err != nil {
 					http.Error(res, err.Error(), http.StatusNotFound)
 				} else {
@@ -189,7 +189,7 @@ func (h *Devices) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 					en.Encode(device)
 				}
 			case http.MethodDelete:
-				err := h.db.DeviceDelete(id)
+				err := deviceDelete(h.db.store, id)
 				if err != nil {
 					http.Error(res, err.Error(), http.StatusNotFound)
 				} else {

--- a/api/devices.go
+++ b/api/devices.go
@@ -10,7 +10,7 @@ import (
 
 // Devices handles device requests
 type Devices struct {
-	db     *db.Db
+	db     *Db
 	influx *db.Influx
 	check  RequestValidator
 }
@@ -210,6 +210,6 @@ type RequestValidator interface {
 }
 
 // NewDevicesHandler returns a new device handler
-func NewDevicesHandler(db *db.Db, influx *db.Influx, v RequestValidator) http.Handler {
+func NewDevicesHandler(db *Db, influx *db.Influx, v RequestValidator) http.Handler {
 	return &Devices{db, influx, v}
 }

--- a/api/devices.go
+++ b/api/devices.go
@@ -65,7 +65,7 @@ func (h *Devices) processConfig(res http.ResponseWriter, req *http.Request, id s
 		return
 	}
 
-	err = h.db.DeviceUpdateConfig(id, c)
+	err = deviceUpdateConfig(h.db.store, id, c)
 	if err != nil {
 		http.Error(res, err.Error(), http.StatusInternalServerError)
 	}

--- a/api/devices.go
+++ b/api/devices.go
@@ -84,7 +84,7 @@ func (h *Devices) processSamples(res http.ResponseWriter, req *http.Request, id 
 	}
 
 	for _, s := range samples {
-		err = h.db.DeviceSample(id, s)
+		err = deviceSample(h.db.store, id, s)
 		if err != nil {
 			http.Error(res, err.Error(), http.StatusInternalServerError)
 		}

--- a/api/server.go
+++ b/api/server.go
@@ -48,7 +48,7 @@ func (h *App) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	}
 
 	switch req.URL.Path {
-	case "/", "/admin", "/devices", "/sign-in":
+	case "/", "/users", "/devices", "/sign-in":
 		h.IndexHandler.ServeHTTP(res, req)
 
 	default:

--- a/api/server.go
+++ b/api/server.go
@@ -77,7 +77,7 @@ func NewAppHandler(args ServerArgs) http.Handler {
 // ServerArgs can be used to pass arguments to the server subsystem
 type ServerArgs struct {
 	Port       string
-	DbInst     *db.Db
+	DbInst     *Db
 	Influx     *db.Influx
 	GetAsset   func(string) []byte
 	Filesystem http.FileSystem

--- a/api/users.go
+++ b/api/users.go
@@ -1,0 +1,98 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/simpleiot/simpleiot/data"
+	"github.com/simpleiot/simpleiot/db"
+)
+
+// Users handles user requests.
+type Users struct {
+	db *db.Db
+}
+
+// NewUsersHandler returns a new handler for user requests.
+func NewUsersHandler(db *db.Db) Users {
+	return Users{db: db}
+}
+
+// ServeHTTP serves user requests.
+func (u Users) ServeHTTP(res http.ResponseWriter, req *http.Request) {
+	var id string
+	id, req.URL.Path = ShiftPath(req.URL.Path)
+
+	if id == "" {
+		switch req.Method {
+		case http.MethodGet:
+			// get all users
+			users, err := u.db.Users()
+			if err != nil {
+				http.Error(res, err.Error(), http.StatusNotFound)
+				return
+			}
+			json.NewEncoder(res).Encode(users)
+			return
+
+		case http.MethodPost:
+			// create user
+			u.createUser(res, req)
+			return
+
+		default:
+			http.Error(res, "invalid method", http.StatusMethodNotAllowed)
+			return
+		}
+	}
+
+	switch req.Method {
+	case http.MethodGet:
+		// get a single user
+		user, err := u.db.User(id)
+		if err != nil {
+			http.Error(res, err.Error(), http.StatusNotFound)
+			return
+		}
+		json.NewEncoder(res).Encode(user)
+		return
+
+	}
+
+	http.Error(res, "invalid method", http.StatusMethodNotAllowed)
+}
+
+func decode(r io.Reader, v interface{}) error {
+	return json.NewDecoder(r).Decode(v)
+}
+
+func encode(w io.Writer, v interface{}) error {
+	return json.NewEncoder(w).Encode(v)
+}
+
+func (u Users) createUser(res http.ResponseWriter, req *http.Request) {
+	var user data.User
+	if err := decode(req.Body, &user); err != nil {
+		http.Error(res, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err := u.db.InsertUser(&user); err != nil {
+		http.Error(res, err.Error(), http.StatusInternalServerError)
+	}
+	encode(res, data.StandardResponse{Success: true, ID: user.ID.String()})
+}
+
+func (u Users) upsertUser(res http.ResponseWriter, req *http.Request, id string) {
+	var user data.User
+	if err := decode(req.Body, &user); err != nil {
+		http.Error(res, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if err := u.db.UserUpsert(id, user); err != nil {
+		http.Error(res, err.Error(), http.StatusInternalServerError)
+	}
+
+	encode(res, data.StandardResponse{Success: true, ID: id})
+}

--- a/api/users.go
+++ b/api/users.go
@@ -6,16 +6,15 @@ import (
 	"net/http"
 
 	"github.com/simpleiot/simpleiot/data"
-	"github.com/simpleiot/simpleiot/db"
 )
 
 // Users handles user requests.
 type Users struct {
-	db *db.Db
+	db *Db
 }
 
 // NewUsersHandler returns a new handler for user requests.
-func NewUsersHandler(db *db.Db) Users {
+func NewUsersHandler(db *Db) Users {
 	return Users{db: db}
 }
 
@@ -77,10 +76,13 @@ func (u Users) createUser(res http.ResponseWriter, req *http.Request) {
 		http.Error(res, err.Error(), http.StatusBadRequest)
 		return
 	}
-	if err := u.db.InsertUser(&user); err != nil {
+
+	id, err := createUser(u.db, user)
+	if err != nil {
 		http.Error(res, err.Error(), http.StatusInternalServerError)
 	}
-	encode(res, data.StandardResponse{Success: true, ID: user.ID.String()})
+
+	encode(res, data.StandardResponse{Success: true, ID: id})
 }
 
 func (u Users) upsertUser(res http.ResponseWriter, req *http.Request, id string) {

--- a/api/v1.go
+++ b/api/v1.go
@@ -30,7 +30,7 @@ func (h *V1) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 }
 
 // NewV1Handler returns a handle for V1 API
-func NewV1Handler(db *db.Db, influx *db.Influx, auth Authorizer) http.Handler {
+func NewV1Handler(db *Db, influx *db.Influx, auth Authorizer) http.Handler {
 	return &V1{
 		UsersHandler:   NewUsersHandler(db),
 		DevicesHandler: NewDevicesHandler(db, influx, auth),

--- a/api/v1.go
+++ b/api/v1.go
@@ -8,6 +8,7 @@ import (
 
 // V1 handles v1 api requests
 type V1 struct {
+	UsersHandler   http.Handler
 	DevicesHandler http.Handler
 	AuthHandler    http.Handler
 }
@@ -17,6 +18,8 @@ func (h *V1) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	var head string
 	head, req.URL.Path = ShiftPath(req.URL.Path)
 	switch head {
+	case "users":
+		h.UsersHandler.ServeHTTP(res, req)
 	case "devices":
 		h.DevicesHandler.ServeHTTP(res, req)
 	case "auth":
@@ -29,6 +32,7 @@ func (h *V1) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 // NewV1Handler returns a handle for V1 API
 func NewV1Handler(db *db.Db, influx *db.Influx, auth Authorizer) http.Handler {
 	return &V1{
+		UsersHandler:   NewUsersHandler(db),
 		DevicesHandler: NewDevicesHandler(db, influx, auth),
 		AuthHandler:    NewAuthHandler(db, auth),
 	}

--- a/cmd/siot/main.go
+++ b/cmd/siot/main.go
@@ -76,7 +76,7 @@ func main() {
 		dataDir = "./"
 	}
 
-	dbInst, err := db.NewDb(dataDir)
+	dbInst, err := api.NewDb(dataDir)
 	if err != nil {
 		log.Println("Error opening db: ", err)
 		os.Exit(-1)

--- a/data/data.go
+++ b/data/data.go
@@ -1,3 +1,2 @@
+// Package data specifies data structures that are used on the wire.
 package data
-
-// data describes common data structures that are used on the wire and for storage

--- a/data/user.go
+++ b/data/user.go
@@ -15,6 +15,7 @@ type User struct {
 }
 
 type Role struct {
+	ID          uuid.UUID `json:"id"`
 	OrgID       uuid.UUID `json:"orgID"`
 	OrgName     string    `json:"orgName"`
 	Description string    `json:"description"`

--- a/data/user.go
+++ b/data/user.go
@@ -11,5 +11,11 @@ type User struct {
 	LastName  string    `json:"lastName"`
 	Email     string    `json:"email"`
 	Pass      string    `json:"pass"`
-	Admin     bool      `json:"admin"`
+	Roles     []Role    `json:"roles"`
+}
+
+type Role struct {
+	OrgID       uuid.UUID `json:"orgID"`
+	OrgName     string    `json:"orgName"`
+	Description string    `json:"description"`
 }

--- a/envsetup.sh
+++ b/envsetup.sh
@@ -1,7 +1,7 @@
 RECOMMENDED_ELM_VERSION=0.19.0
 
 if [ -z "$GOPATH" ]; then
-  export GOPATH=~/go
+  export GOPATH=$HOME/go
 fi
 
 export GOBIN=$GOPATH/bin

--- a/frontend2/src/Pages/Devices.elm
+++ b/frontend2/src/Pages/Devices.elm
@@ -1,6 +1,6 @@
 module Pages.Devices exposing (Model, Msg, page)
 
-import Dict exposing (Dict, get, insert)
+import Dict exposing (Dict)
 import Element exposing (..)
 import Element.Background as Background
 import Element.Border as Border
@@ -19,7 +19,7 @@ import Spa.Types as Types
 import Time
 import Url.Builder as Url
 import Utils.Spa exposing (Page)
-import Utils.Styles exposing (size)
+import Utils.Styles exposing (size, palette)
 
 
 page : Page Params.Devices Model Msg model msg appMsg
@@ -313,17 +313,6 @@ descriptionField id config modded =
                     text "description"
         , label = Input.labelHidden "Description"
         }
-
-
-palette =
-    { black = rgb 0 0 0
-    , gray = rgb 0.5 0.5 0.5
-    , pale = rgba 0.97 0.97 0.97 0.75
-    , red = rgba 1 0.7 0.7 0.75
-    , orange = rgb 1 1 0.8
-    , yellow = rgb 1 1 0.7
-    , green = rgba 0.7 1 0.7 0.75
-    }
 
 
 fieldAttrs : Bool -> Msg -> Msg -> List (Attribute Msg)

--- a/frontend2/src/Pages/Users.elm
+++ b/frontend2/src/Pages/Users.elm
@@ -1,0 +1,405 @@
+module Pages.Users exposing (Model, Msg, page)
+
+import Dict exposing (Dict)
+import Element exposing (..)
+import Element.Background as Background
+import Element.Border as Border
+import Element.Font as Font
+import Element.Input as Input
+import Generated.Params as Params
+import Global
+import Http
+import Json.Decode as Decode
+import Json.Decode.Pipeline exposing (hardcoded, optional, required)
+import Json.Encode as Encode
+import Spa.Page
+import Spa.Types as Types
+import Url.Builder as Url
+import Utils.Spa exposing (Page)
+import Utils.Styles exposing (palette, size)
+
+
+page : Page Params.Users Model Msg model msg appMsg
+page =
+    Spa.Page.element
+        { title = always "Users"
+        , init = init
+        , update = update
+        , subscriptions = always subscriptions
+        , view = always view
+        }
+
+
+
+-- INIT
+
+
+type alias Model =
+    { users : List User
+    , userEdits : Dict String User
+    , error : Maybe Http.Error
+    }
+
+
+emptyUser =
+    { id = ""
+    , admin = False
+    , email = ""
+    , first = ""
+    , last = ""
+    }
+
+init : Types.PageContext route Global.Model -> Params.Users -> ( Model, Cmd Msg )
+init context _ =
+    ( { users = []
+      , userEdits = Dict.empty
+      , error = Nothing
+      }
+    , case context.global of
+        Global.SignedIn sess ->
+            getUsers sess.authToken
+
+        Global.SignedOut _ ->
+            Cmd.none
+    )
+
+
+
+-- UPDATE
+
+
+type Msg
+    = UpdateUsers (Result Http.Error (List User))
+    | PostUser String User
+    | UserPosted String (Result Http.Error Response)
+    | EditUser String User
+    | DiscardUserEdits String
+    | NewUser
+
+
+type alias User =
+    { id : String
+    , first : String
+    , last : String
+    , email : String
+    , admin : Bool
+
+    --, roles : List String
+    }
+
+
+update : Types.PageContext route Global.Model -> Msg -> Model -> ( Model, Cmd Msg )
+update context msg model =
+    case msg of
+        UpdateUsers (Ok users) ->
+            ( { model | users = users }
+            , Cmd.none
+            )
+
+        UpdateUsers (Err err) ->
+            ( { model | error = Just err }
+            , Cmd.none
+            )
+
+        UserPosted id (Ok _) ->
+            ( { model | userEdits = Dict.remove id model.userEdits }
+            , case context.global of
+                Global.SignedIn sess ->
+                    getUsers sess.authToken
+
+                Global.SignedOut _ ->
+                    Cmd.none
+            )
+
+        EditUser id user ->
+            ( { model | userEdits = Dict.insert id user model.userEdits }
+            , Cmd.none
+            )
+
+        DiscardUserEdits id ->
+            ( { model | userEdits = Dict.remove id model.userEdits }
+            , Cmd.none
+            )
+
+        PostUser id user ->
+            ( model
+            , case context.global of
+                Global.SignedIn sess ->
+                    postUser sess.authToken user.id user
+
+                Global.SignedOut _ ->
+                    Cmd.none
+            )
+
+        NewUser ->
+            ( { model | users = emptyUser :: model.users }
+            , Cmd.none
+            )
+
+        _ ->
+            ( model
+            , Cmd.none
+            )
+
+
+getUsers : String -> Cmd Msg
+getUsers token =
+    Http.request
+        { method = "GET"
+        , headers = [ Http.header "Authorization" <| "Bearer " ++ token ]
+        , url = Url.absolute [ "v1", "users" ] []
+        , expect = Http.expectJson UpdateUsers usersDecoder
+        , body = Http.emptyBody
+        , timeout = Nothing
+        , tracker = Nothing
+        }
+
+
+usersDecoder : Decode.Decoder (List User)
+usersDecoder =
+    Decode.list userDecoder
+
+
+userDecoder =
+    Decode.succeed User
+        |> required "id" Decode.string
+        |> required "firstName" Decode.string
+        |> required "lastName" Decode.string
+        |> required "email" Decode.string
+        |> optional "admin" Decode.bool False
+
+
+
+-- SUBSCRIPTIONS
+
+
+subscriptions : Model -> Sub Msg
+subscriptions model =
+    Sub.none
+
+
+
+-- VIEW
+
+
+view : Model -> Element Msg
+view model =
+    column
+        [ width fill, spacing 32 ]
+        [ el [ padding 16, Font.size 24 ] <| text "Users"
+        , viewError model.error
+        , el [ width fill, Font.bold ] <| button "new user" palette.green NewUser
+        , viewUsers model.userEdits model.users
+        ]
+
+
+viewError error =
+    case error of
+        Just (Http.BadUrl str) ->
+            text <| "bad URL: " ++ str
+
+        Just Http.Timeout ->
+            text "timeout"
+
+        Just Http.NetworkError ->
+            text "network error"
+
+        Just (Http.BadStatus status) ->
+            text <| "bad status: " ++ String.fromInt status
+
+        Just (Http.BadBody str) ->
+            text <| "bad body: " ++ str
+
+        Nothing ->
+            none
+
+
+viewUsers edits users =
+    column
+        [ width fill
+        , spacing 40
+        ]
+    <|
+        List.map
+            (\user -> viewUser
+                (modified edits user)
+                (userValue edits user))
+            users
+
+
+viewUser modded user =
+    wrappedRow
+        ([ width fill
+         , Border.widthEach { top = 2, bottom = 0, left = 0, right = 0 }
+         , Border.color palette.black
+         , spacing 6
+         ]
+            ++ (if modded then
+                    [ Background.color palette.orange
+                    , below <|
+                        buttonRow
+                            [ button "discard" palette.pale <| DiscardUserEdits user.id
+                            , button "save" palette.green <| PostUser user.id user
+                            ]
+                    ]
+
+                else
+                    []
+               )
+        )
+        [ viewTextProperty
+            { name = "First name"
+            , value = user.first
+            , action = \x -> EditUser user.id { user | first = x }
+            }
+        , viewTextProperty
+            { name = "Last name"
+            , value = user.last
+            , action = \x -> EditUser user.id { user | last = x }
+            }
+        , viewTextProperty
+            { name = "Email"
+            , value = user.email
+            , action = \x -> EditUser user.id { user | email = x }
+            }
+        , viewRoles
+            [ { role = "user"
+              , value = True
+              , action = \x -> EditUser user.id user
+              }
+            , { role = "admin"
+              , value = user.admin
+              , action = \x -> EditUser user.id { user | admin = x }
+              }
+            ]
+        ]
+
+
+buttonRow : List (Element Msg) -> Element Msg
+buttonRow =
+    row
+        [ Font.size 16
+        , Font.bold
+        , width fill
+        , padding 16
+        , spacing 16
+        ]
+
+
+button : String -> Color -> Msg -> Element Msg
+button lbl color action =
+    Input.button
+        [ Background.color color
+        , padding 16
+        , width fill
+        , Border.rounded 32
+        ]
+        { onPress = Just action
+        , label = el [ centerX ] <| text lbl
+        }
+
+
+modified edits user =
+    case Dict.get user.id edits of
+        Just u ->
+            u /= user
+
+        Nothing ->
+            False
+
+
+userValue edits user =
+    case Dict.get user.id edits of
+        Just u ->
+            u
+
+        Nothing ->
+            user
+
+
+field edits user fld =
+    case Dict.get user.id edits of
+        Just u ->
+            fld u
+
+        Nothing ->
+            fld user
+
+
+viewTextProperty { name, value, action } =
+    Input.text
+        [ padding 16
+        , width (fill |> minimum 150)
+        , Border.width 0
+        , Border.rounded 0
+        , focused [ Background.color palette.yellow ]
+        , Background.color palette.pale
+        , spacing 0
+        ]
+        { onChange = action
+        , text = value
+        , placeholder = Nothing
+        , label = label Input.labelAbove name
+        }
+
+
+label kind =
+    kind
+        [ padding 16
+        , Font.italic
+        , Font.color palette.gray
+        ]
+        << text
+
+
+viewRoles =
+    row
+        []
+        << List.map viewRole
+
+
+viewRole { role, value, action } =
+    Input.checkbox
+        [ padding 16 ]
+        { checked = value
+        , icon = Input.defaultCheckbox
+        , label = label Input.labelRight role
+        , onChange = action
+        }
+
+
+postUser : String -> String -> User -> Cmd Msg
+postUser token id user =
+    Http.request
+        { method = "POST"
+        , headers = [ Http.header "Authorization" <| "Bearer " ++ token ]
+        , url = Url.absolute [ "v1", "users", id ] []
+        , expect = Http.expectJson (UserPosted id) responseDecoder
+        , body = user |> userEncoder |> Http.jsonBody
+        , timeout = Nothing
+        , tracker = Nothing
+        }
+
+
+userEncoder : User -> Encode.Value
+userEncoder user =
+    Encode.object
+        [ ( "firstName", Encode.string user.first )
+        , ( "lastName", Encode.string user.last )
+        , ( "email", Encode.string user.email )
+        ]
+
+
+type alias Response =
+    { success : Bool
+    , error : String
+    , id : String
+    }
+
+
+responseDecoder : Decode.Decoder Response
+responseDecoder =
+    Decode.succeed Response
+        |> required "success" Decode.bool
+        |> optional "error" Decode.string ""
+        |> optional "id" Decode.string ""

--- a/frontend2/src/Utils/Styles.elm
+++ b/frontend2/src/Utils/Styles.elm
@@ -2,6 +2,7 @@ module Utils.Styles exposing
     ( button
     , error
     , colors
+    , palette
     , fonts
     , size
     , h1
@@ -22,6 +23,18 @@ colors =
     , jet = rgb255 40 40 40
     , coral = rgb255 204 75 75
     }
+
+
+palette =
+    { black = rgb 0 0 0
+    , gray = rgb 0.5 0.5 0.5
+    , pale = rgba 0.97 0.97 0.97 0.9
+    , red = rgba 1 0.7 0.7 0.75
+    , orange = rgb 1 1 0.8
+    , yellow = rgb 1 1 0.7
+    , green = rgba 0.7 1 0.7 0.9
+    }
+
 
 
 fonts =

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/gorilla/websocket v1.4.0
 	github.com/influxdata/influxdb1-client v0.0.0-20190809212627-fc22c7df067e
 	github.com/jacobsa/go-serial v0.0.0-20180131005756-15cf729a72d4
-	github.com/timshannon/bolthold v0.0.0-20180829183128-83840edea944
+	github.com/timshannon/bolthold v0.0.0-20200316231344-dc30e2b2f90c
 	go.etcd.io/bbolt v1.3.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/influxdata/influxdb1-client v0.0.0-20190809212627-fc22c7df067e
 	github.com/jacobsa/go-serial v0.0.0-20180131005756-15cf729a72d4
 	github.com/timshannon/bolthold v0.0.0-20180829183128-83840edea944
-	go.etcd.io/bbolt v1.3.0 // indirect
+	go.etcd.io/bbolt v1.3.0
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/stretchr/testify v1.2.1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/timshannon/bolthold v0.0.0-20180829183128-83840edea944 h1:gpP0SE4FIbe/r8ES2eLrs7iWmg7j9ipvqM2c+0aDJu8=
 github.com/timshannon/bolthold v0.0.0-20180829183128-83840edea944/go.mod h1:jUigdmrbdCxcIDEFrq82t4X9805XZfwFZoYUap0ET/U=
+github.com/timshannon/bolthold v0.0.0-20200316231344-dc30e2b2f90c h1:B+GHkv+kVfUdmpbEPsQYM+WrPBJdNohEwBrBqxXh0d0=
+github.com/timshannon/bolthold v0.0.0-20200316231344-dc30e2b2f90c/go.mod h1:jUigdmrbdCxcIDEFrq82t4X9805XZfwFZoYUap0ET/U=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=
 go.etcd.io/bbolt v1.3.0 h1:oY10fI923Q5pVCVt1GBTZMn8LHo5M+RCInFpeMnV4QI=


### PR DESCRIPTION
The main changes:

1. Created the user list page, which allows creating new and editing certain properties of existing users. Role functionality is visible and not yet implemented.

2. Started using bolt transactions. Given that each transaction is driven by the needs of the API call being served, it felt right to expose bolthold.Store in package api and diminish the role of package db. The data store itself shouldn't have to think about API calls, and the API shouldn't have to think about transactions. We maintain strict separation between code that serves HTTP requests and code that implements transactions, even though it's all in package api at the moment. It will be easy to move the transactions somewhere else.

Next, I intend to work on orgs.
