### PR TITLE
api: Update user roles correctly

### DIFF
--- a/api/db.go
+++ b/api/db.go
@@ -517,23 +517,34 @@ func updateUser(store *bolthold.Store, user data.User) error {
 			return err
 		}
 
-		// TODO: What if the set of roles changes?
-		// This code is incorrect! Consider embedding roles.
 		for _, role := range user.Roles {
+			// The frontend, when creating new roles, does not choose
+			// a UUID; that is the backend's responsibility. Thus if the
+			// given role ID is zero, it means the role is new and needs
+			// a fresh ID. Hence, we need to call TxUpsert rather than
+			// TxUpdate, so that new roles will be created automatically.
 			role := Role{
-				ID:          role.ID,
+				ID:          newIfZero(role.ID),
 				UserID:      u.ID,
 				OrgID:       role.OrgID,
 				Description: role.Description,
 			}
-			if err := store.TxUpdate(tx, role.ID, role); err != nil {
+			if err := store.TxUpsert(tx, role.ID, role); err != nil {
 				return err
 			}
 		}
 
-		// remove roles present in the database and not in the new data
-		return updateRoles()
+		// We also need to remove roles present in the
+		// database and absent from the new set of roles.
+		return cleanRoles(store, tx, user.ID, user.Roles)
 	})
+}
+
+func newIfZero(id uuid.UUID) uuid.UUID {
+	if id == zero {
+		return uuid.New()
+	}
+	return id
 }
 
 func containsRole(id uuid.UUID, roles []data.Role) bool {
@@ -545,7 +556,26 @@ func containsRole(id uuid.UUID, roles []data.Role) bool {
 	return false
 }
 
-func updateRoles() error {
+func cleanRoles(store *bolthold.Store, tx *bolt.Tx, userID uuid.UUID, newRoles []data.Role) error {
+	// get the current set of roles
+	roles, err := userRoles(store, tx, userID)
+	if err != nil {
+		return err
+	}
+
+	var targets []Role
+	for _, role := range roles {
+		if !containsRole(role.ID, newRoles) {
+			targets = append(targets, role)
+		}
+	}
+
+	for _, target := range targets {
+		if err := store.TxDelete(tx, target.ID, target); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/api/db.go
+++ b/api/db.go
@@ -530,8 +530,19 @@ func updateUser(store *bolthold.Store, user data.User) error {
 				return err
 			}
 		}
+
+		// remove roles present in the database and not in the new data
 		return nil
 	})
+}
+
+func containsRole(id uuid.UUID, roles []data.Role) bool {
+	for _, role := range roles {
+		if id == role.ID {
+			return true
+		}
+	}
+	return false
 }
 
 // Orgs returns all orgs.

--- a/api/db.go
+++ b/api/db.go
@@ -532,7 +532,7 @@ func updateUser(store *bolthold.Store, user data.User) error {
 		}
 
 		// remove roles present in the database and not in the new data
-		return nil
+		return updateRoles()
 	})
 }
 
@@ -543,6 +543,10 @@ func containsRole(id uuid.UUID, roles []data.Role) bool {
 		}
 	}
 	return false
+}
+
+func updateRoles() error {
+	return nil
 }
 
 // Orgs returns all orgs.


### PR DESCRIPTION
The frontend is capable of modifying the set of roles of a user in one request. To support this, we have to do several things:

1. Assign UUIDs to roles that do not yet exist and insert them
2. Update existing roles that have been modified
3. Remove roles that have been deleted