### PR TITLE
Refactor orgs page

### DIFF
--- a/frontend2/src/Global.elm
+++ b/frontend2/src/Global.elm
@@ -58,6 +58,7 @@ type alias Cred =
 type Msg
     = Tick Time.Posix
     | UpdateDevices (Result Http.Error (List D.Device))
+    | UpdateOrgs (Result Http.Error (List O.Org))
     | SignIn Cred
     | AuthResponse Cred (Result Http.Error Auth)
     | UpdateData (Result Http.Error Data)

--- a/frontend2/src/Global.elm
+++ b/frontend2/src/Global.elm
@@ -62,6 +62,7 @@ type Msg
     | SignIn Cred
     | AuthResponse Cred (Result Http.Error Auth)
     | DataResponse (Result Http.Error Data)
+    | RequestOrgs
     | SignOut
 
 

--- a/frontend2/src/Global.elm
+++ b/frontend2/src/Global.elm
@@ -57,7 +57,7 @@ type alias Cred =
 
 type Msg
     = Tick Time.Posix
-    | UpdateDevices (Result Http.Error (List D.Device))
+    | DevicesResponse (Result Http.Error (List D.Device))
     | UpdateOrgs (Result Http.Error (List O.Org))
     | SignIn Cred
     | AuthResponse Cred (Result Http.Error Auth)
@@ -202,7 +202,7 @@ update commands msg model =
                     , Cmd.none
                     )
 
-                UpdateDevices (Ok devices) ->
+                DevicesResponse (Ok devices) ->
                     ( SignedIn { sess | data = { data | devices = devices } }
                     , Cmd.none
                     , Cmd.none
@@ -221,7 +221,7 @@ getDevices token =
         { method = "GET"
         , headers = [ Http.header "Authorization" <| "Bearer " ++ token ]
         , url = urlDevices
-        , expect = Http.expectJson UpdateDevices D.decodeList
+        , expect = Http.expectJson DevicesResponse D.decodeList
         , body = Http.emptyBody
         , timeout = Nothing
         , tracker = Nothing

--- a/frontend2/src/Global.elm
+++ b/frontend2/src/Global.elm
@@ -215,7 +215,6 @@ update commands msg model =
                     )
 
 
-
 getDevices : String -> Cmd Msg
 getDevices token =
     Http.request
@@ -231,6 +230,19 @@ getDevices token =
 
 urlDevices =
     Url.absolute [ "v1", "devices" ] []
+
+
+getOrgs : String -> Cmd Msg
+getOrgs token =
+    Http.request
+        { method = "GET"
+        , headers = [ Http.header "Authorization" <| "Bearer " ++ token ]
+        , url = Url.absolute [ "v1", "orgs" ] []
+        , expect = Http.expectJson UpdateOrgs O.decodeList
+        , body = Http.emptyBody
+        , timeout = Nothing
+        , tracker = Nothing
+        }
 
 
 subscriptions : Model -> Sub Msg

--- a/frontend2/src/Global.elm
+++ b/frontend2/src/Global.elm
@@ -209,6 +209,12 @@ update commands msg model =
                     , Cmd.none
                     )
 
+                RequestOrgs ->
+                    ( model
+                    , getOrgs sess.authToken
+                    , Cmd.none
+                    )
+
                 _ ->
                     ( model
                     , Cmd.none

--- a/frontend2/src/Global.elm
+++ b/frontend2/src/Global.elm
@@ -91,7 +91,7 @@ login cred =
         }
 
 
-loadData token =
+getData token =
     Http.request
         { method = "GET"
         , headers = [ Http.header "Authorization" <| "Bearer " ++ token ]
@@ -162,7 +162,7 @@ update commands msg model =
                         , privilege = privilege
                         , data = emptyData
                         }
-                    , loadData token
+                    , getData token
                     , Cmd.none
                     )
 

--- a/frontend2/src/Global.elm
+++ b/frontend2/src/Global.elm
@@ -191,8 +191,8 @@ update commands msg model =
                     , commands.navigate routes.signIn
                     )
 
-                UpdateData (Ok data) ->
-                    ( SignedIn { sess | data = data }
+                UpdateData (Ok newData) ->
+                    ( SignedIn { sess | data = newData }
                     , Cmd.none
                     , Cmd.none
                     )

--- a/frontend2/src/Global.elm
+++ b/frontend2/src/Global.elm
@@ -58,10 +58,10 @@ type alias Cred =
 type Msg
     = Tick Time.Posix
     | DevicesResponse (Result Http.Error (List D.Device))
-    | UpdateOrgs (Result Http.Error (List O.Org))
+    | OrgsResponse (Result Http.Error (List O.Org))
     | SignIn Cred
     | AuthResponse Cred (Result Http.Error Auth)
-    | UpdateData (Result Http.Error Data)
+    | DataResponse (Result Http.Error Data)
     | SignOut
 
 
@@ -96,7 +96,7 @@ getData token =
         { method = "GET"
         , headers = [ Http.header "Authorization" <| "Bearer " ++ token ]
         , url = Url.absolute [ "v1", "data" ] []
-        , expect = Http.expectJson UpdateData decodeData
+        , expect = Http.expectJson DataResponse decodeData
         , body = Http.emptyBody
         , timeout = Nothing
         , tracker = Nothing
@@ -196,7 +196,7 @@ update commands msg model =
                     , commands.navigate routes.signIn
                     )
 
-                UpdateData (Ok newData) ->
+                DataResponse (Ok newData) ->
                     ( SignedIn { sess | data = newData }
                     , Cmd.none
                     , Cmd.none
@@ -238,7 +238,7 @@ getOrgs token =
         { method = "GET"
         , headers = [ Http.header "Authorization" <| "Bearer " ++ token ]
         , url = Url.absolute [ "v1", "orgs" ] []
-        , expect = Http.expectJson UpdateOrgs O.decodeList
+        , expect = Http.expectJson OrgsResponse O.decodeList
         , body = Http.emptyBody
         , timeout = Nothing
         , tracker = Nothing

--- a/frontend2/src/Global.elm
+++ b/frontend2/src/Global.elm
@@ -172,6 +172,10 @@ update commands msg model =
                     )
 
         SignedIn sess ->
+            let
+                data =
+                    sess.data
+            in
             case msg of
                 Tick _ ->
                     ( model
@@ -198,10 +202,6 @@ update commands msg model =
                     )
 
                 UpdateDevices (Ok devices) ->
-                    let
-                        data =
-                            sess.data
-                    in
                     ( SignedIn { sess | data = { data | devices = devices } }
                     , Cmd.none
                     , Cmd.none

--- a/frontend2/src/Pages/Orgs.elm
+++ b/frontend2/src/Pages/Orgs.elm
@@ -80,6 +80,14 @@ type Msg
     | EditEmail String String
 
 
+update2 : Msg -> Model -> ( Model, Cmd Msg, Cmd Global.Msg )
+update2 msg model =
+    ( model
+    , Cmd.none
+    , Cmd.none
+    )
+
+
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of

--- a/frontend2/src/Pages/Orgs.elm
+++ b/frontend2/src/Pages/Orgs.elm
@@ -131,20 +131,20 @@ view context model =
         , viewError model.error
         , case context.global of
             Global.SignedIn sess ->
-                viewOrgs model
+                viewOrgs model.emails model.orgs
 
             _ ->
                 el [ padding 16 ] <| text "Sign in to view your orgs."
         ]
 
 
-viewOrgs model =
+viewOrgs emails orgs =
     column
         [ width fill
         , spacing 40
         ]
     <|
-        List.map (viewOrg model.emails) model.orgs
+        List.map (viewOrg emails) orgs
 
 
 getEmail emails orgId =

--- a/frontend2/src/Pages/Orgs.elm
+++ b/frontend2/src/Pages/Orgs.elm
@@ -91,8 +91,12 @@ type Msg
 
 update2 : Msg -> Model -> ( Model, Cmd Msg, Cmd Global.Msg )
 update2 msg model =
-    ( model
-    , Cmd.none
+    let
+        (model_, msg_) =
+            update msg model
+    in
+    ( model_
+    , msg_
     , Cmd.none
     )
 

--- a/frontend2/src/Pages/Orgs.elm
+++ b/frontend2/src/Pages/Orgs.elm
@@ -43,18 +43,11 @@ type alias Model =
 
 init : Types.PageContext route Global.Model -> Params.Orgs -> ( Model, Cmd Msg, Cmd Global.Msg )
 init context _ =
-    case context.global of
-        Global.SignedIn sess ->
-            ( empty
-            , Cmd.none
-            , Cmd.none
-            )
+    ( empty
+    , Cmd.none
+    , Cmd.none
+    )
 
-        Global.SignedOut _ ->
-            ( empty
-            , Cmd.none
-            , Cmd.none
-            )
 
 
 empty =

--- a/frontend2/src/Pages/Orgs.elm
+++ b/frontend2/src/Pages/Orgs.elm
@@ -45,6 +45,17 @@ type alias Model =
     }
 
 
+init2 : Types.PageContext route Global.Model -> Params.Orgs -> ( Model, Cmd Msg, Cmd Global.Msg )
+init2 _ _ =
+    ( { orgs = []
+      , error = Nothing
+      , emails = Dict.empty
+      }
+    , Cmd.none
+    , Cmd.none
+    )
+
+
 init : Types.PageContext route Global.Model -> Params.Orgs -> ( Model, Cmd Msg )
 init context _ =
     ( { orgs = []

--- a/frontend2/src/Pages/Orgs.elm
+++ b/frontend2/src/Pages/Orgs.elm
@@ -67,18 +67,23 @@ init2 context params =
 
 init : Types.PageContext route Global.Model -> Params.Orgs -> ( Model, Cmd Msg )
 init context _ =
-    ( { orgs = []
-      , error = Nothing
-      , emails = Dict.empty
-      }
-    , case context.global of
+    case context.global of
         Global.SignedIn sess ->
-            getOrgs sess.authToken
+            ( empty
+            , getOrgs sess.authToken
+            )
 
         Global.SignedOut _ ->
-            Cmd.none
-    )
+            ( empty
+            , Cmd.none
+            )
 
+
+empty =
+    { orgs = []
+    , error = Nothing
+    , emails = Dict.empty
+    }
 
 
 -- UPDATE

--- a/frontend2/src/Pages/Orgs.elm
+++ b/frontend2/src/Pages/Orgs.elm
@@ -86,6 +86,7 @@ empty =
     }
 
 
+
 -- UPDATE
 
 
@@ -97,7 +98,7 @@ type Msg
 update2 : Msg -> Model -> ( Model, Cmd Msg, Cmd Global.Msg )
 update2 msg model =
     let
-        (model_, msg_) =
+        ( model_, msg_ ) =
             update msg model
     in
     ( model_

--- a/frontend2/src/Pages/Orgs.elm
+++ b/frontend2/src/Pages/Orgs.elm
@@ -31,6 +31,7 @@ page =
         }
 
 
+page2 : Page Params.Orgs Model Msg model msg appMsg
 page2 =
     Spa.Page.component
         { title = always "Orgs"

--- a/frontend2/src/Pages/Orgs.elm
+++ b/frontend2/src/Pages/Orgs.elm
@@ -36,8 +36,7 @@ page =
 
 
 type alias Model =
-    { orgs : List O.Org
-    , error : Maybe Http.Error
+    { error : Maybe Http.Error
     , emails : Dict String String
     }
 
@@ -59,8 +58,7 @@ init context _ =
 
 
 empty =
-    { orgs = []
-    , error = Nothing
+    { error = Nothing
     , emails = Dict.empty
     }
 

--- a/frontend2/src/Pages/Orgs.elm
+++ b/frontend2/src/Pages/Orgs.elm
@@ -22,17 +22,6 @@ import Utils.Styles exposing (palette, size)
 
 page : Page Params.Orgs Model Msg model msg appMsg
 page =
-    Spa.Page.element
-        { title = always "Orgs"
-        , init = init
-        , update = always update
-        , subscriptions = always subscriptions
-        , view = always view
-        }
-
-
-page2 : Page Params.Orgs Model Msg model msg appMsg
-page2 =
     Spa.Page.component
         { title = always "Orgs"
         , init = init2

--- a/frontend2/src/Pages/Orgs.elm
+++ b/frontend2/src/Pages/Orgs.elm
@@ -24,8 +24,8 @@ page : Page Params.Orgs Model Msg model msg appMsg
 page =
     Spa.Page.component
         { title = always "Orgs"
-        , init = init2
-        , update = always update2
+        , init = init
+        , update = always update
         , subscriptions = always subscriptions
         , view = always view
         }
@@ -42,28 +42,18 @@ type alias Model =
     }
 
 
-init2 : Types.PageContext route Global.Model -> Params.Orgs -> ( Model, Cmd Msg, Cmd Global.Msg )
-init2 context params =
-    let
-        ( model, msg ) =
-            init context params
-    in
-    ( model
-    , msg
-    , Cmd.none
-    )
-
-
-init : Types.PageContext route Global.Model -> Params.Orgs -> ( Model, Cmd Msg )
+init : Types.PageContext route Global.Model -> Params.Orgs -> ( Model, Cmd Msg, Cmd Global.Msg )
 init context _ =
     case context.global of
         Global.SignedIn sess ->
             ( empty
             , getOrgs sess.authToken
+            , Cmd.none
             )
 
         Global.SignedOut _ ->
             ( empty
+            , Cmd.none
             , Cmd.none
             )
 
@@ -84,33 +74,24 @@ type Msg
     | EditEmail String String
 
 
-update2 : Msg -> Model -> ( Model, Cmd Msg, Cmd Global.Msg )
-update2 msg model =
-    let
-        ( model_, msg_ ) =
-            update msg model
-    in
-    ( model_
-    , msg_
-    , Cmd.none
-    )
-
-
-update : Msg -> Model -> ( Model, Cmd Msg )
+update : Msg -> Model -> ( Model, Cmd Msg, Cmd Global.Msg )
 update msg model =
     case msg of
         UpdateOrgs (Ok orgs) ->
             ( { model | orgs = orgs }
+            , Cmd.none
             , Cmd.none
             )
 
         UpdateOrgs (Err err) ->
             ( { model | error = Just err }
             , Cmd.none
+            , Cmd.none
             )
 
         EditEmail id email ->
             ( { model | emails = Dict.insert id email model.emails }
+            , Cmd.none
             , Cmd.none
               -- TODO: does this user exist?
             )

--- a/frontend2/src/Pages/Orgs.elm
+++ b/frontend2/src/Pages/Orgs.elm
@@ -124,12 +124,17 @@ subscriptions model =
 
 
 view : Types.PageContext route Global.Model -> Model -> Element Msg
-view _ model =
+view context model =
     column
         [ width fill, spacing 32 ]
         [ el [ padding 16, Font.size 24 ] <| text "Orgs"
         , viewError model.error
-        , viewOrgs model
+        , case context.global of
+            Global.SignedIn sess ->
+                viewOrgs model
+
+            _ ->
+                el [ padding 16 ] <| text "Sign in to view your orgs."
         ]
 
 

--- a/frontend2/src/Pages/Orgs.elm
+++ b/frontend2/src/Pages/Orgs.elm
@@ -70,25 +70,12 @@ empty =
 
 
 type Msg
-    = UpdateOrgs (Result Http.Error (List O.Org))
-    | EditEmail String String
+    = EditEmail String String
 
 
 update : Msg -> Model -> ( Model, Cmd Msg, Cmd Global.Msg )
 update msg model =
     case msg of
-        UpdateOrgs (Ok orgs) ->
-            ( { model | orgs = orgs }
-            , Cmd.none
-            , Cmd.none
-            )
-
-        UpdateOrgs (Err err) ->
-            ( { model | error = Just err }
-            , Cmd.none
-            , Cmd.none
-            )
-
         EditEmail id email ->
             ( { model | emails = Dict.insert id email model.emails }
             , Cmd.none

--- a/frontend2/src/Pages/Orgs.elm
+++ b/frontend2/src/Pages/Orgs.elm
@@ -33,6 +33,12 @@ page =
 
 page2 =
     Spa.Page.component
+        { title = always "Orgs"
+        , init = init2
+        , update = always update2
+        , subscriptions = always subscriptions
+        , view = always view
+        }
 
 
 -- INIT

--- a/frontend2/src/Pages/Orgs.elm
+++ b/frontend2/src/Pages/Orgs.elm
@@ -47,7 +47,7 @@ init context _ =
     case context.global of
         Global.SignedIn sess ->
             ( empty
-            , getOrgs sess.authToken
+            , Cmd.none
             , Cmd.none
             )
 

--- a/frontend2/src/Pages/Orgs.elm
+++ b/frontend2/src/Pages/Orgs.elm
@@ -97,19 +97,6 @@ update msg model =
             )
 
 
-getOrgs : String -> Cmd Msg
-getOrgs token =
-    Http.request
-        { method = "GET"
-        , headers = [ Http.header "Authorization" <| "Bearer " ++ token ]
-        , url = Url.absolute [ "v1", "orgs" ] []
-        , expect = Http.expectJson UpdateOrgs O.decodeList
-        , body = Http.emptyBody
-        , timeout = Nothing
-        , tracker = Nothing
-        }
-
-
 
 -- SUBSCRIPTIONS
 

--- a/frontend2/src/Pages/Orgs.elm
+++ b/frontend2/src/Pages/Orgs.elm
@@ -131,7 +131,7 @@ view context model =
         , viewError model.error
         , case context.global of
             Global.SignedIn sess ->
-                viewOrgs model.emails model.orgs
+                viewOrgs model.emails sess.data.orgs
 
             _ ->
                 el [ padding 16 ] <| text "Sign in to view your orgs."

--- a/frontend2/src/Pages/Orgs.elm
+++ b/frontend2/src/Pages/Orgs.elm
@@ -31,6 +31,9 @@ page =
         }
 
 
+page2 =
+    Spa.Page.component
+
 
 -- INIT
 

--- a/frontend2/src/Pages/Orgs.elm
+++ b/frontend2/src/Pages/Orgs.elm
@@ -42,6 +42,7 @@ page2 =
         }
 
 
+
 -- INIT
 
 
@@ -53,12 +54,13 @@ type alias Model =
 
 
 init2 : Types.PageContext route Global.Model -> Params.Orgs -> ( Model, Cmd Msg, Cmd Global.Msg )
-init2 _ _ =
-    ( { orgs = []
-      , error = Nothing
-      , emails = Dict.empty
-      }
-    , Cmd.none
+init2 context params =
+    let
+        ( model, msg ) =
+            init context params
+    in
+    ( model
+    , msg
     , Cmd.none
     )
 

--- a/frontend2/src/Pages/Orgs.elm
+++ b/frontend2/src/Pages/Orgs.elm
@@ -179,10 +179,6 @@ viewDevices =
     viewList "Devices" viewDevice
 
 
-dup a =
-    (++) a a
-
-
 viewOrgName name =
     el
         [ padding 16

--- a/frontend2/src/Pages/Orgs.elm
+++ b/frontend2/src/Pages/Orgs.elm
@@ -27,7 +27,7 @@ page =
         , init = init
         , update = always update
         , subscriptions = always subscriptions
-        , view = always view
+        , view = view
         }
 
 
@@ -123,8 +123,8 @@ subscriptions model =
 -- VIEW
 
 
-view : Model -> Element Msg
-view model =
+view : Types.PageContext route Global.Model -> Model -> Element Msg
+view _ model =
     column
         [ width fill, spacing 32 ]
         [ el [ padding 16, Font.size 24 ] <| text "Orgs"

--- a/frontend2/src/Pages/Orgs.elm
+++ b/frontend2/src/Pages/Orgs.elm
@@ -45,7 +45,7 @@ init : Types.PageContext route Global.Model -> Params.Orgs -> ( Model, Cmd Msg, 
 init context _ =
     ( empty
     , Cmd.none
-    , Cmd.none
+    , Spa.Page.send <| Global.RequestOrgs
     )
 
 


### PR DESCRIPTION
The orgs page now refers to global state to get the list of orgs. In addition, it can send a message requesting that the org list be updated. The HTTP request has been moved to the Global module.