### PR TITLE
frontend2: move device update polling to devices page

### DIFF
--- a/frontend2/src/Global.elm
+++ b/frontend2/src/Global.elm
@@ -261,6 +261,4 @@ getOrgs token =
 
 subscriptions : Model -> Sub Msg
 subscriptions _ =
-    Sub.batch
-        [ Time.every 1000 Tick
-        ]
+    Sub.none

--- a/frontend2/src/Global.elm
+++ b/frontend2/src/Global.elm
@@ -63,6 +63,7 @@ type Msg
     | AuthResponse Cred (Result Http.Error Auth)
     | DataResponse (Result Http.Error Data)
     | RequestOrgs
+    | RequestDevices
     | SignOut
 
 
@@ -212,6 +213,12 @@ update commands msg model =
                 RequestOrgs ->
                     ( model
                     , getOrgs sess.authToken
+                    , Cmd.none
+                    )
+
+                RequestDevices ->
+                    ( model
+                    , getDevices sess.authToken
                     , Cmd.none
                     )
 

--- a/frontend2/src/Global.elm
+++ b/frontend2/src/Global.elm
@@ -56,8 +56,7 @@ type alias Cred =
 
 
 type Msg
-    = Tick Time.Posix
-    | DevicesResponse (Result Http.Error (List D.Device))
+    = DevicesResponse (Result Http.Error (List D.Device))
     | OrgsResponse (Result Http.Error (List O.Org))
     | SignIn Cred
     | AuthResponse Cred (Result Http.Error Auth)
@@ -180,12 +179,6 @@ update commands msg model =
                     sess.data
             in
             case msg of
-                Tick _ ->
-                    ( model
-                    , getDevices sess.authToken
-                    , Cmd.none
-                    )
-
                 SignOut ->
                     ( SignedOut Nothing
                     , Cmd.none

--- a/frontend2/src/Pages/Devices.elm
+++ b/frontend2/src/Pages/Devices.elm
@@ -132,7 +132,9 @@ type alias DeviceEdit =
 
 subscriptions : Types.PageContext route Global.Model -> Model -> Sub Msg
 subscriptions context model =
-    Sub.none
+    Sub.batch
+        [ Time.every 1000 Tick
+        ]
 
 
 

--- a/frontend2/src/Pages/Devices.elm
+++ b/frontend2/src/Pages/Devices.elm
@@ -107,6 +107,12 @@ update context msg model =
             , Cmd.none
             )
 
+        Tick _ ->
+            ( model
+            , Cmd.none
+            , Spa.Page.send <| Global.RequestDevices
+            )
+
         _ ->
             ( model
             , Cmd.none

--- a/frontend2/src/Pages/Devices.elm
+++ b/frontend2/src/Pages/Devices.elm
@@ -24,6 +24,7 @@ import Spa.Types as Types
 import Url.Builder as Url
 import Utils.Spa exposing (Page)
 import Utils.Styles exposing (palette, size)
+import Time
 
 
 page : Page Params.Devices Model Msg model msg appMsg
@@ -59,7 +60,8 @@ init _ =
 
 
 type Msg
-    = EditDeviceDescription DeviceEdit
+    = Tick Time.Posix
+    | EditDeviceDescription DeviceEdit
     | PostConfig String D.Config
     | DiscardEditedDeviceDescription String
     | ConfigPosted String (Result Http.Error Response)

--- a/frontend2/src/Pages/Devices.elm
+++ b/frontend2/src/Pages/Devices.elm
@@ -29,7 +29,7 @@ import Time
 
 page : Page Params.Devices Model Msg model msg appMsg
 page =
-    Spa.Page.element
+    Spa.Page.component
         { title = always "Devices"
         , init = always init
         , update = update
@@ -47,10 +47,11 @@ type alias Model =
     }
 
 
-init : Params.Devices -> ( Model, Cmd Msg )
+init : Params.Devices -> ( Model, Cmd Msg, Cmd Global.Msg )
 init _ =
     ( { deviceEdits = Dict.empty
       }
+    , Cmd.none
     , Cmd.none
     )
 
@@ -74,11 +75,12 @@ type alias Response =
     }
 
 
-update : Types.PageContext route Global.Model -> Msg -> Model -> ( Model, Cmd Msg )
+update : Types.PageContext route Global.Model -> Msg -> Model -> ( Model, Cmd Msg, Cmd Global.Msg )
 update context msg model =
     case msg of
         EditDeviceDescription { id, description } ->
             ( { model | deviceEdits = Dict.insert id description model.deviceEdits }
+            , Cmd.none
             , Cmd.none
             )
 
@@ -90,20 +92,24 @@ update context msg model =
 
                 Global.SignedOut _ ->
                     Cmd.none
+            , Cmd.none
             )
 
         ConfigPosted id (Ok _) ->
             ( { model | deviceEdits = Dict.remove id model.deviceEdits }
+            , Cmd.none
             , Cmd.none
             )
 
         DiscardEditedDeviceDescription id ->
             ( { model | deviceEdits = Dict.remove id model.deviceEdits }
             , Cmd.none
+            , Cmd.none
             )
 
         _ ->
             ( model
+            , Cmd.none
             , Cmd.none
             )
 


### PR DESCRIPTION
This allows us to poll the device list only when the devices page is being viewed.