### PR TITLE
frontend2: add roles to orgs page

### DIFF
--- a/frontend2/src/Global.elm
+++ b/frontend2/src/Global.elm
@@ -203,6 +203,12 @@ update commands msg model =
                     , Cmd.none
                     )
 
+                OrgsResponse (Ok orgs) ->
+                    ( SignedIn { sess | data = { data | orgs = orgs } }
+                    , Cmd.none
+                    , Cmd.none
+                    )
+
                 RequestOrgs ->
                     ( model
                     , getOrgs sess.authToken

--- a/frontend2/src/Global.elm
+++ b/frontend2/src/Global.elm
@@ -32,6 +32,7 @@ type alias Session =
     , authToken : String
     , privilege : Privilege
     , data : Data
+    , error : Maybe Http.Error
     }
 
 
@@ -162,6 +163,7 @@ update commands msg model =
                         , cred = cred
                         , privilege = privilege
                         , data = emptyData
+                        , error = Nothing
                         }
                     , getData token
                     , Cmd.none

--- a/frontend2/src/Pages/Orgs.elm
+++ b/frontend2/src/Pages/Orgs.elm
@@ -215,12 +215,12 @@ viewUser user =
         , text user.last
         , viewRole
             { role = "user"
-            , value = True
+            , value = hasRole "user" user
             , action = EditRole
             }
         , viewRole
             { role = "admin"
-            , value = True
+            , value = hasRole "admin" user
             , action = EditRole
             }
         ]

--- a/frontend2/src/Pages/Orgs.elm
+++ b/frontend2/src/Pages/Orgs.elm
@@ -226,6 +226,10 @@ viewUser user =
         ]
 
 
+hasRole role user =
+    List.member role <| List.map .description user.roles
+
+
 viewRole { role, value, action } =
     Input.checkbox
         [ padding 16 ]

--- a/frontend2/src/Pages/Orgs.elm
+++ b/frontend2/src/Pages/Orgs.elm
@@ -62,6 +62,7 @@ empty =
 
 type Msg
     = EditEmail String String
+    | EditRole String Bool
 
 
 update : Msg -> Model -> ( Model, Cmd Msg, Cmd Global.Msg )
@@ -74,6 +75,11 @@ update msg model =
               -- TODO: does this user exist?
             )
 
+        _ ->
+            ( model
+            , Cmd.none
+            , Cmd.none
+            )
 
 
 -- SUBSCRIPTIONS
@@ -207,6 +213,16 @@ viewUser user =
     viewItem
         [ text user.first
         , text user.last
+        , viewRole
+            { role = "user"
+            , value = True
+            , action = EditRole
+            }
+        , viewRole
+            { role = "admin"
+            , value = True
+            , action = EditRole
+            }
         ]
 
 
@@ -216,7 +232,7 @@ viewRole { role, value, action } =
         { checked = value
         , icon = Input.defaultCheckbox
         , label = label Input.labelRight role
-        , onChange = action
+        , onChange = action role
         }
 
 

--- a/frontend2/src/Pages/Orgs.elm
+++ b/frontend2/src/Pages/Orgs.elm
@@ -210,6 +210,16 @@ viewUser user =
         ]
 
 
+viewRole { role, value, action } =
+    Input.checkbox
+        [ padding 16 ]
+        { checked = value
+        , icon = Input.defaultCheckbox
+        , label = label Input.labelRight role
+        , onChange = action
+        }
+
+
 viewDevice : Device.Device -> Element Msg
 viewDevice device =
     viewItem

--- a/frontend2/src/Pages/Users.elm
+++ b/frontend2/src/Pages/Users.elm
@@ -231,16 +231,6 @@ viewUser modded user =
             , value = user.email
             , action = \x -> EditUser user.id { user | email = x }
             }
-        , viewRoles
-            [ { role = "user"
-              , value = True
-              , action = \x -> EditUser user.id user
-              }
-            , { role = "admin"
-              , value = user.admin
-              , action = \x -> EditUser user.id { user | admin = x }
-              }
-            ]
         ]
 
 

--- a/frontend2/src/User.elm
+++ b/frontend2/src/User.elm
@@ -47,6 +47,7 @@ encode user =
         , ( "email", Encode.string user.email )
         ]
 
+
 type alias Role =
     { id : String
     , orgID : String
@@ -54,3 +55,11 @@ type alias Role =
     , description : String
     }
 
+
+encodeRole role =
+    Encode.object
+        [ ( "id", Encode.string role.id )
+        , ( "orgID", Encode.string role.orgID )
+        , ( "orgName", Encode.string role.orgName )
+        , ( "description", Encode.string role.description )
+        ]

--- a/frontend2/src/User.elm
+++ b/frontend2/src/User.elm
@@ -46,3 +46,11 @@ encode user =
         , ( "lastName", Encode.string user.last )
         , ( "email", Encode.string user.email )
         ]
+
+type alias Role =
+    { id : String
+    , orgID : String
+    , orgName : String
+    , description : String
+    }
+

--- a/frontend2/src/User.elm
+++ b/frontend2/src/User.elm
@@ -15,13 +15,11 @@ type alias User =
     , first : String
     , last : String
     , email : String
-    , admin : Bool
     }
 
 
 empty =
     { id = ""
-    , admin = False
     , email = ""
     , first = ""
     , last = ""
@@ -39,7 +37,6 @@ decode =
         |> required "firstName" Decode.string
         |> required "lastName" Decode.string
         |> required "email" Decode.string
-        |> optional "admin" Decode.bool False
 
 
 encode : User -> Encode.Value

--- a/frontend2/src/User.elm
+++ b/frontend2/src/User.elm
@@ -63,3 +63,10 @@ encodeRole role =
         , ( "orgName", Encode.string role.orgName )
         , ( "description", Encode.string role.description )
         ]
+
+decodeRole =
+    Decode.succeed Role
+        |> required "id" Decode.string
+        |> required "orgID" Decode.string
+        |> required "orgName" Decode.string
+        |> required "description" Decode.string

--- a/frontend2/src/User.elm
+++ b/frontend2/src/User.elm
@@ -15,6 +15,7 @@ type alias User =
     , first : String
     , last : String
     , email : String
+    , roles : List Role
     }
 
 
@@ -23,6 +24,7 @@ empty =
     , email = ""
     , first = ""
     , last = ""
+    , roles = []
     }
 
 
@@ -37,6 +39,7 @@ decode =
         |> required "firstName" Decode.string
         |> required "lastName" Decode.string
         |> required "email" Decode.string
+        |> required "roles" decodeRoles
 
 
 encode : User -> Encode.Value
@@ -45,6 +48,7 @@ encode user =
         [ ( "firstName", Encode.string user.first )
         , ( "lastName", Encode.string user.last )
         , ( "email", Encode.string user.email )
+        , ( "roles", encodeRoles user.roles )
         ]
 
 
@@ -64,9 +68,17 @@ encodeRole role =
         , ( "description", Encode.string role.description )
         ]
 
+
+encodeRoles =
+    Encode.list encodeRole
+
+
 decodeRole =
     Decode.succeed Role
         |> required "id" Decode.string
         |> required "orgID" Decode.string
         |> required "orgName" Decode.string
         |> required "description" Decode.string
+
+decodeRoles =
+    Decode.list decodeRole


### PR DESCRIPTION
Main changes:

- Added an error field to the global model when signed in, which is displayed in Layout.elm. This should probably evolve into a "status" indicator.
- Moved role display from users page to orgs page.
- Partial implementation of editing roles.

# Future thoughts

We may want to consider changing the wire data structures used to encode roles (_data.Role_), so that they are easier for the front end to work with. The SQL-style data isn't a good fit. It may be that the storage types should also be changed.

One of the questions raised by this work is whether a user having multiple roles in an organization means anything. Obviously, the most general approach is to permit this, but that could lead to complexity in implementation if this generality isn't necessary. We could use radio buttons instead of checkboxes, or checkbox groups that permit at most one of them being checked.