### PR TITLE
Do not unset GOARCH globally

### DIFF
--- a/envsetup.sh
+++ b/envsetup.sh
@@ -9,13 +9,11 @@ export GOBIN=$GOPATH/bin
 # map tools from project go modules
 
 genesis() {
-  unset GOARCH
-  go run github.com/benbjohnson/genesis/cmd/genesis "$@"
+  GOARCH= go run github.com/benbjohnson/genesis/cmd/genesis "$@"
 }
 
 golint() {
-  unset GOARCH
-  go run golang.org/x/lint/golint "$@"
+  GOARCH= go run golang.org/x/lint/golint "$@"
 }
 
 bbolt() {


### PR DESCRIPTION
This changes GOARCH everywhere if unexported instead surgically set it
for this cmd alone

Signed-off-by: Khem Raj <raj.khem@gmail.com>