### PR TITLE
Modbus phase 2

### DIFF
--- a/data/schema.go
+++ b/data/schema.go
@@ -14,6 +14,7 @@ const (
 	PointTypeAddress            = "address"
 	PointTypeDebug              = "debug"
 	PointTypeInitialized        = "initialized"
+	PointTypePollPeriod         = "pollPeriod"
 
 	// An device node describes an phyical device -- it may be the
 	// cloud server, gateway, etc

--- a/data/schema.go
+++ b/data/schema.go
@@ -4,17 +4,23 @@ package data
 // the system.
 const (
 	// general point types
-	PointTypeDescription string = "description"
-	PointTypeScale              = "scale"
-	PointTypeOffset             = "offset"
-	PointTypeUnits              = "units"
-	PointTypeValue              = "value"
-	PointTypeValueSet           = "valueSet"
-	PointTypeID                 = "id"
-	PointTypeAddress            = "address"
-	PointTypeDebug              = "debug"
-	PointTypeInitialized        = "initialized"
-	PointTypePollPeriod         = "pollPeriod"
+	PointTypeDescription        string = "description"
+	PointTypeScale                     = "scale"
+	PointTypeOffset                    = "offset"
+	PointTypeUnits                     = "units"
+	PointTypeValue                     = "value"
+	PointTypeValueSet                  = "valueSet"
+	PointTypeID                        = "id"
+	PointTypeAddress                   = "address"
+	PointTypeDebug                     = "debug"
+	PointTypeInitialized               = "initialized"
+	PointTypePollPeriod                = "pollPeriod"
+	PointTypeErrorCount                = "errorCount"
+	PointTypeErrorCountReset           = "errorCountReset"
+	PointTypeErrorCountEOF             = "errorCountEOF"
+	PointTypeErrorCountEOFReset        = "errorCountEOFReset"
+	PointTypeErrorCountCRC             = "errorCountCRC"
+	PointTypeErrorCountCRCReset        = "errorCountCRCReset"
 
 	// An device node describes an phyical device -- it may be the
 	// cloud server, gateway, etc

--- a/envsetup.sh
+++ b/envsetup.sh
@@ -114,7 +114,7 @@ siot_deploy() {
 siot_run() {
   echo "run args: $*"
   siot_build_dependencies --debug || return 1
-  go run cmd/siot/main.go "$@" || return 1
+  go run -race cmd/siot/main.go "$@" || return 1
   return 0
 }
 

--- a/frontend/src/Api/Point.elm
+++ b/frontend/src/Api/Point.elm
@@ -32,6 +32,7 @@ module Api.Point exposing
     , typeOffset
     , typePass
     , typePhone
+    , typePollPeriod
     , typePort
     , typeScale
     , typeStartApp
@@ -244,6 +245,11 @@ typeDataFormat =
 typeDebug : String
 typeDebug =
     "debug"
+
+
+typePollPeriod : String
+typePollPeriod =
+    "pollPeriod"
 
 
 valueUINT16 : String

--- a/frontend/src/Api/Point.elm
+++ b/frontend/src/Api/Point.elm
@@ -23,6 +23,12 @@ module Api.Point exposing
     , typeDebug
     , typeDescription
     , typeEmail
+    , typeErrorCount
+    , typeErrorCountCRC
+    , typeErrorCountCRCReset
+    , typeErrorCountEOF
+    , typeErrorCountEOFReset
+    , typeErrorCountReset
     , typeFirstName
     , typeHwVersion
     , typeID
@@ -210,6 +216,36 @@ typeID =
 typeAddress : String
 typeAddress =
     "address"
+
+
+typeErrorCount : String
+typeErrorCount =
+    "errorCount"
+
+
+typeErrorCountEOF : String
+typeErrorCountEOF =
+    "errorCountEOF"
+
+
+typeErrorCountCRC : String
+typeErrorCountCRC =
+    "errorCountCRC"
+
+
+typeErrorCountReset : String
+typeErrorCountReset =
+    "errorCountReset"
+
+
+typeErrorCountEOFReset : String
+typeErrorCountEOFReset =
+    "errorCountEOFReset"
+
+
+typeErrorCountCRCReset : String
+typeErrorCountCRCReset =
+    "errorCountCRCReset"
 
 
 typeModbusIOType : String

--- a/frontend/src/Components/NodeModbus.elm
+++ b/frontend/src/Components/NodeModbus.elm
@@ -51,7 +51,7 @@ view o =
                 { onEditNodePoint = o.onEditNodePoint
                 , node = o.node
                 , now = o.now
-                , labelWidth = labelWidth
+                , labelWidth = labelWidth + 120
                 }
 
         optionInput =

--- a/frontend/src/Components/NodeModbus.elm
+++ b/frontend/src/Components/NodeModbus.elm
@@ -46,6 +46,14 @@ view o =
                 , labelWidth = labelWidth
                 }
 
+        counterWithReset =
+            Form.nodeCounterWithReset
+                { onEditNodePoint = o.onEditNodePoint
+                , node = o.node
+                , now = o.now
+                , labelWidth = labelWidth
+                }
+
         optionInput =
             Form.nodeOptionInput
                 { onEditNodePoint = o.onEditNodePoint
@@ -82,6 +90,9 @@ view o =
                         numberInput Point.typeID "Device ID"
                     , numberInput Point.typePollPeriod "Poll period (ms)"
                     , numberInput Point.typeDebug "Debug level (0-9)"
+                    , counterWithReset Point.typeErrorCount Point.typeErrorCountReset "Error Count"
+                    , counterWithReset Point.typeErrorCountEOF Point.typeErrorCountEOFReset "EOF Error Count"
+                    , counterWithReset Point.typeErrorCountCRC Point.typeErrorCountCRCReset "CRC Error Count"
                     , viewIf o.modified <|
                         Form.buttonRow
                             [ Form.button

--- a/frontend/src/Components/NodeModbus.elm
+++ b/frontend/src/Components/NodeModbus.elm
@@ -80,6 +80,7 @@ view o =
                     , textInput Point.typeBaud "Baud"
                     , viewIf (clientServer == Point.valueServer) <|
                         numberInput Point.typeID "Device ID"
+                    , numberInput Point.typePollPeriod "Poll period (ms)"
                     , numberInput Point.typeDebug "Debug level (0-9)"
                     , viewIf o.modified <|
                         Form.buttonRow

--- a/frontend/src/Components/NodeModbusIO.elm
+++ b/frontend/src/Components/NodeModbusIO.elm
@@ -67,7 +67,7 @@ view o =
                 { onEditNodePoint = o.onEditNodePoint
                 , node = o.node
                 , now = o.now
-                , labelWidth = labelWidth
+                , labelWidth = labelWidth + 150
                 }
 
         modbusIOType =

--- a/frontend/src/Components/NodeModbusIO.elm
+++ b/frontend/src/Components/NodeModbusIO.elm
@@ -62,6 +62,14 @@ view o =
                 , labelWidth = labelWidth
                 }
 
+        counterWithReset =
+            Form.nodeCounterWithReset
+                { onEditNodePoint = o.onEditNodePoint
+                , node = o.node
+                , now = o.now
+                , labelWidth = labelWidth
+                }
+
         modbusIOType =
             Point.getText o.node.points Point.typeModbusIOType
 
@@ -170,6 +178,9 @@ view o =
                         numberInput Point.typeValue "Value"
                     , viewIf (not isClient && modbusIOType == Point.valueModbusDiscreteInput) <|
                         onOffInput Point.typeValue Point.typeValue "Value"
+                    , counterWithReset Point.typeErrorCount Point.typeErrorCountReset "Error Count"
+                    , counterWithReset Point.typeErrorCountEOF Point.typeErrorCountEOFReset "EOF Error Count"
+                    , counterWithReset Point.typeErrorCountCRC Point.typeErrorCountCRCReset "CRC Error Count"
                     , viewIf o.modified <|
                         Form.buttonRow
                             [ Form.button

--- a/frontend/src/UI/Form.elm
+++ b/frontend/src/UI/Form.elm
@@ -2,6 +2,7 @@ module UI.Form exposing
     ( button
     , buttonRow
     , label
+    , nodeCounterWithReset
     , nodeNumberInput
     , nodeOnOffInput
     , nodeOptionInput
@@ -205,6 +206,51 @@ nodeOptionInput o pointName lbl options =
                 )
                 options
         }
+
+
+nodeCounterWithReset :
+    { onEditNodePoint : String -> Point -> msg
+    , node : Node
+    , now : Time.Posix
+    , labelWidth : Int
+    }
+    -> String
+    -> String
+    -> String
+    -> Element msg
+nodeCounterWithReset o pointName pointResetName lbl =
+    let
+        currentValue =
+            Point.getValue o.node.points pointName
+
+        currentResetValue =
+            Point.getValue o.node.points pointResetName /= 0
+    in
+    row [ spacing 20 ]
+        [ el [ width (px o.labelWidth) ] <|
+            el [ alignRight ] <|
+                text <|
+                    lbl
+                        ++ ": "
+                        ++ String.fromFloat currentValue
+        , Input.checkbox []
+            { onChange =
+                \v ->
+                    let
+                        vFloat =
+                            if v then
+                                1.0
+
+                            else
+                                0
+                    in
+                    o.onEditNodePoint o.node.id (Point "" pointResetName 0 o.now vFloat "" 0 0)
+            , icon = Input.defaultCheckbox
+            , checked = currentResetValue
+            , label =
+                Input.labelLeft [] (text "reset")
+            }
+        ]
 
 
 nodeOnOffInput :

--- a/modbus/crc.go
+++ b/modbus/crc.go
@@ -25,8 +25,8 @@ func RtuCrc(buf []byte) uint16 {
 	return (crc >> 8) | (crc << 8)
 }
 
-// ErrCrc is returned if a crc check fails
-var ErrCrc = errors.New("CRC error")
+// ErrCRC is returned if a crc check fails
+var ErrCRC = errors.New("CRC error")
 
 // ErrNotEnoughData is returned if not enough data
 var ErrNotEnoughData = errors.New("Not enough data to calculate CRC")
@@ -41,7 +41,7 @@ func CheckRtuCrc(packet []byte) error {
 
 	crcPacket := binary.BigEndian.Uint16(packet[len(packet)-2 : len(packet)])
 	if crcCalc != crcPacket {
-		return ErrCrc
+		return ErrCRC
 	}
 
 	return nil

--- a/modbus/modbus.go
+++ b/modbus/modbus.go
@@ -27,6 +27,8 @@ const (
 	WriteCoilValueOff uint16 = 0
 )
 
+// this is the total length of the packet with id and CRC bytes
+// you can view these raw packets by increasing debug level to 9
 var minPacketLen = map[FunctionCode]int{
 	FuncCodeReadCoils:            6,
 	FuncCodeReadDiscreteInputs:   6,

--- a/modbus/pdu.go
+++ b/modbus/pdu.go
@@ -81,7 +81,7 @@ func (p *PDU) ProcessRequest(regs *Regs) ([]RegChange, PDU, error) {
 				"error writing to coil reg")
 		}
 
-		resp.Data = PutUint16Array(v)
+		resp = *p
 
 	case FuncCodeWriteSingleRegister:
 		address := binary.BigEndian.Uint16(p.Data[:2])

--- a/node/node.go
+++ b/node/node.go
@@ -67,7 +67,7 @@ func (m *Manager) Run() {
 
 		m.modbusManager.Update()
 
-		time.Sleep(10 * time.Second)
+		time.Sleep(5 * time.Second)
 	}
 }
 

--- a/node/node.go
+++ b/node/node.go
@@ -34,6 +34,13 @@ func NewManger(db *genji.Db, messenger *msg.Messenger, nc *natsgo.Conn) *Manager
 
 // Run manager
 func (m *Manager) Run() {
+	go func() {
+		for {
+			m.modbusManager.Update()
+			time.Sleep(1 * time.Second)
+		}
+	}()
+
 	for {
 		nodes, err := m.db.Nodes()
 		if err != nil {
@@ -41,6 +48,7 @@ func (m *Manager) Run() {
 			time.Sleep(10 * time.Second)
 			continue
 		}
+
 		for _, node := range nodes {
 			// update node state
 			state, changed := node.UpdateState()
@@ -65,9 +73,6 @@ func (m *Manager) Run() {
 			}
 		}
 
-		m.modbusManager.Update()
-
-		time.Sleep(5 * time.Second)
 	}
 }
 


### PR DESCRIPTION
Phase 2 of modbus implementation. [Previous PR](https://github.com/simpleiot/simpleiot/pull/110)


* [x] - handle removing modbus bus
* [x] - add poll rate field
* [x] - handle changing modbus parameters (port, etc)
* [x] - track error stats for bus
* [x] - client: log errors when server does not respond
* [x] - handle changing modbus IO params (address, etc). This regs on server need to be re-initialized.
* [x] - client: Coil, error: not enough data for function code 5, expected 7, got 6
* [x] - track error stats for IOs
* [x] - CRC errors on server
* [x] - fix race condition in respreader
* [ ] - fix race condition in modbus runners
* [ ] - changing bus params does not restart Run()
* [ ] - are we counting errors on server?
* [ ] - make changes more responsive -- perhaps leverage nats bus more, and reg changes
* [ ] - figure out how to handle precision with 32-bit floats and knowing when they are set vs just precision errors
* [ ] - better handle number of decimal places displayed
