### PR TITLE
Improve Modbus functionality

### DIFF
--- a/modbus/modbus.go
+++ b/modbus/modbus.go
@@ -1,5 +1,7 @@
 package modbus
 
+import "fmt"
+
 // FunctionCode represents a modbus function code
 type FunctionCode byte
 
@@ -7,18 +9,34 @@ type FunctionCode byte
 const (
 	// Bit access
 	FuncCodeReadDiscreteInputs FunctionCode = 2
-	FuncCodeReadCoils                       = 1
-	FuncCodeWriteSingleCoil                 = 5
-	FuncCodeWriteMultipleCoils              = 15
+	FuncCodeReadCoils          FunctionCode = 1
+	FuncCodeWriteSingleCoil    FunctionCode = 5
+	FuncCodeWriteMultipleCoils FunctionCode = 15
 
 	// 16-bit access
-	FuncCodeReadInputRegisters         = 4
-	FuncCodeReadHoldingRegisters       = 3
-	FuncCodeWriteSingleRegister        = 6
-	FuncCodeWriteMultipleRegisters     = 16
-	FuncCodeReadWriteMultipleRegisters = 23
-	FuncCodeMaskWriteRegister          = 22
-	FuncCodeReadFIFOQueue              = 24
+	FuncCodeReadInputRegisters         FunctionCode = 4
+	FuncCodeReadHoldingRegisters       FunctionCode = 3
+	FuncCodeWriteSingleRegister        FunctionCode = 6
+	FuncCodeWriteMultipleRegisters     FunctionCode = 16
+	FuncCodeReadWriteMultipleRegisters FunctionCode = 23
+	FuncCodeMaskWriteRegister          FunctionCode = 22
+	FuncCodeReadFIFOQueue              FunctionCode = 24
+)
+
+// ExceptionCode represents a modbus exception code
+type ExceptionCode byte
+
+// Defined valid exception codes
+const (
+	ExcIllegalFunction              ExceptionCode = 1
+	ExcIllegalAddress               ExceptionCode = 2
+	ExcIllegalValue                 ExceptionCode = 3
+	ExcServerDeviceFailure          ExceptionCode = 4
+	ExcAcknowledge                  ExceptionCode = 5
+	ExcServerDeviceBusy             ExceptionCode = 6
+	ExcMemoryParityError            ExceptionCode = 8
+	ExcGatewayPathUnavilable        ExceptionCode = 0x0a
+	ExcGatewayTargetFailedToRespond ExceptionCode = 0x0b
 )
 
 // define valid values for write coil
@@ -34,4 +52,28 @@ var minPacketLen = map[FunctionCode]int{
 	FuncCodeReadInputRegisters:   7,
 	FuncCodeWriteSingleCoil:      7,
 	FuncCodeWriteSingleRegister:  7,
+}
+
+func (e ExceptionCode) Error() string {
+	switch e {
+	case 1:
+		return "ILLEGAL FUNCTION"
+	case 2:
+		return "ILLEGAL DATA ADDRESS"
+	case 3:
+		return "ILLEGAL DATA VALUE"
+	case 4:
+		return "SERVER DEVICE FAILURE"
+	case 5:
+		return "ACKNOWLEDGE"
+	case 6:
+		return "SERVER DEVICE BUSY"
+	case 8:
+		return "MEMORY PARITY ERROR"
+	case 0x0a:
+		return "GATEWAY PATH UNAVAILABLE"
+	case 0x0B:
+		return "GATEWAY TARGET DEVICE FAILED TO RESPOND"
+	}
+	return fmt.Sprintf("unknown exception code %x", int(e))
 }

--- a/modbus/pdu_test.go
+++ b/modbus/pdu_test.go
@@ -32,6 +32,53 @@ func TestPduReadCoils(t *testing.T) {
 	}
 }
 
+func TestPduWriteSingleCoil(t *testing.T) {
+	regs := Regs{}
+	regs.AddCoil(128) // add register 8 for coil 128
+	regs.WriteCoil(128, true)
+
+	pdu := WriteSingleCoil(128, false)
+
+	_, resp, err := pdu.ProcessRequest(&regs)
+
+	if err != nil {
+		t.Errorf("Error processing request: %v", err)
+	}
+
+	if got, want := resp.FunctionCode, FuncCodeWriteSingleCoil; got != want {
+		t.Errorf("got function code %x, want %x", got, want)
+	}
+
+	data := Uint16Array(resp.Data)
+	if got, want := data[0], uint16(128); got != want {
+		t.Errorf("got address %d, want %d", got, want)
+	}
+	if got, want := data[1], uint16(0); got != want {
+		t.Errorf("got value %d, want %d", got, want)
+	}
+}
+
+func TestPduWriteSingleCoilError(t *testing.T) {
+	regs := Regs{}
+	regs.AddCoil(128) // add register 8 for coil 128
+	regs.WriteCoil(128, true)
+
+	pdu := WriteSingleCoil(64, false)
+
+	_, resp, err := pdu.ProcessRequest(&regs)
+
+	if err != nil {
+		t.Errorf("Error processing request: %v", err)
+	}
+
+	if got, want := resp.FunctionCode, 0x80|FuncCodeWriteSingleCoil; got != want {
+		t.Errorf("got function code %x, want %x", got, want)
+	}
+	if len(resp.Data) != 1 || resp.Data[0] != byte(ExcIllegalAddress) {
+		t.Errorf("got exception code %x, want %x", resp.Data[0], byte(ExcIllegalAddress))
+	}
+}
+
 func TestPduReadHoldingRegs(t *testing.T) {
 	regs := Regs{}
 	regs.AddReg(8, 1)

--- a/modbus/reg.go
+++ b/modbus/reg.go
@@ -1,7 +1,6 @@
 package modbus
 
 import (
-	"errors"
 	"sync"
 )
 
@@ -62,7 +61,7 @@ func (r *Regs) readReg(address int) (uint16, error) {
 		}
 	}
 
-	return 0, errors.New("register not found")
+	return 0, ExcIllegalAddress
 }
 
 // ReadReg is used to read a modbus holding register
@@ -86,7 +85,7 @@ func (r *Regs) writeReg(address int, value uint16) error {
 		}
 	}
 
-	return errors.New("register not found")
+	return ExcIllegalAddress
 }
 
 // WriteReg is used to write a modbus register


### PR DESCRIPTION
This PR makes a few improvements to the Modbus package:

- Invalid addresses and errors generate proper Modbus exception reports, instead of silently ignoring the request
- `PDU.ProcessRequest` takes an interface for registers, instead of a concrete `*Regs`. This allows the user to supply their own backing store that handles different function codes separately.
- The response for Write Single Coil is fixed to have the correct form.
- Tests are added for these cases.

I think there's a few things I could still do but I didn't want to bite them off in the same PR because I had some questions about how best to implement them:
- The `RegProvider` interface could be split into multiple interfaces, one for each function code, and `ProcessRequest` could use type assertions to check if the corresponding function code is supported. I didn't do that here because I couldn't think of a way to do that without making ProcessRequest take an `interface{}`, which would be confusing for the user.
- The `Server` struct still has a concrete `Regs` object, so if you want to use `ProcessRequest` with a custom register provider, you need to reimplement `Listen`. I didn't want to make this change because it would be a non-backwards-compatible API change. If you're okay with that change I think it would be the next logical step.
- A much more complete test suite should be written that covers all the supported function codes.

With these changes, I'm using this package with TinyGo to implement a Modbus slave in a microcontroller. Thanks for providing such an awesome package to build on!