### PR TITLE
Use forked version of goselect

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,4 +55,6 @@ replace (
 	github.com/genjidb/genji/engine/badgerengine => github.com/genjidb/genji/engine/badgerengine v0.9.1-0.20201128170130-7bce05780a49
 )
 
+replace github.com/creack/goselect => github.com/kraj/goselect v0.0.0-20210218064725-d62c8d3140a5
+
 go 1.14

--- a/go.sum
+++ b/go.sum
@@ -136,6 +136,9 @@ github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kraj/goselect v0.0.0-20210218064725-d62c8d3140a5 h1:y3iYVqr3i52Xb643/fyMHQfEDtmqGmoPlSl8vt/qq5o=
+github.com/kraj/goselect v0.0.0-20210218064725-d62c8d3140a5/go.mod h1:a/NhLweNvqIYMuxcMOuWY516Cimucms3DglDzQP3hKY=
+github.com/kraj/goselect v0.1.1/go.mod h1:a/NhLweNvqIYMuxcMOuWY516Cimucms3DglDzQP3hKY=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.7 h1:bQGKb3vps/j0E9GfJQ03JyhRuxsvdAanXlT9BTw3mdw=


### PR DESCRIPTION
Implement rv32/rv64 support as submitted upstream
https://github.com/creack/goselect/pull/16

Fixes
https://github.com/simpleiot/simpleiot/issues/137

Signed-off-by: Khem Raj <raj.khem@gmail.com>