### PR TITLE
Used Go embed instead of genesis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-/frontend/output
 /frontend/src/Generated
 elm-stuff
 /siot
@@ -8,7 +7,6 @@ elm-stuff
 temp
 tags
 .idea
-assets.go
 node_modules
 dist
 data.json
@@ -17,3 +15,5 @@ GITHUB_TOKEN
 local.sh
 /badger
 /frontend/.elm-spa
+frontend/output/
+/assets/frontend/output/

--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,3 @@ local.sh
 /badger
 /frontend/.elm-spa
 frontend/output/
-/assets/frontend/output/

--- a/assets/files/files.go
+++ b/assets/files/files.go
@@ -3,6 +3,7 @@ package files
 import (
 	"bytes"
 	"fmt"
+	"github.com/simpleiot/simpleiot/assets/frontend"
 	"io/ioutil"
 	"os"
 	"path"
@@ -23,7 +24,7 @@ func UpdateFiles(dataDir string) error {
 
 	for _, fu := range fileUpdates {
 		f := path.Base(fu.Dest)
-		fBytes := Asset(path.Join("/", f))
+		fBytes := frontend.Asset(path.Join("/", f))
 		if fBytes == nil {
 			return fmt.Errorf("Error opening update for: %v", f)
 		}

--- a/assets/frontend/assets.go
+++ b/assets/frontend/assets.go
@@ -10,7 +10,7 @@ import (
 var content embed.FS
 
 func Asset(name string) []byte {
-	const filePath = "frontend/output"
+	const filePath = "output"
 	temp, err := content.ReadFile(path.Join(filePath, name))
 	if err != nil {
 		return nil

--- a/assets/frontend/assets.go
+++ b/assets/frontend/assets.go
@@ -1,0 +1,23 @@
+package frontend
+
+import (
+	"embed"
+	"net/http"
+	"path"
+)
+
+//go:embed output/*
+var content embed.FS
+
+func Asset(name string) []byte {
+	const filePath = "frontend/output"
+	temp, err := content.ReadFile(path.Join(filePath, name))
+	if err != nil {
+		return nil
+	}
+	return temp
+}
+
+func FileSystem() http.FileSystem {
+	return http.FS(content)
+}

--- a/envsetup.sh
+++ b/envsetup.sh
@@ -2,10 +2,6 @@ RECOMMENDED_ELM_VERSION=0.19.1
 
 # map tools from project go modules
 
-genesis() {
-  GOARCH='' go run github.com/benbjohnson/genesis/cmd/genesis "$@"
-}
-
 golint() {
   GOARCH='' go run golang.org/x/lint/golint "$@"
 }
@@ -53,29 +49,17 @@ siot_build_frontend() {
   ELMARGS=$1
   echo "Elm args: $ELMARGS"
   rm -f "frontend/output"/*
+  rm -f "assets/frontend/output"/*
   (cd "frontend" && npx elm-spa build) || return 1
   (cd "frontend" && npx elm make "$ELMARGS" src/Main.elm --output=output/elm.js) || return 1
-  cp "frontend/public"/* "frontend/output/" || return 1
-  cp "frontend/public/index.html" "frontend/output/index.html" || return 1
-  cp docs/simple-iot-app-logo.png "frontend/output/" || return 1
+  cp "frontend/public"/* "assets/frontend/output" || return 1
+  cp "frontend/public/index.html" "assets/frontend/output/index.html" || return 1
+  cp docs/simple-iot-app-logo.png "assets/frontend/output/" || return 1
   return 0
 }
 
 siot_build_assets() {
   mkdir -p assets/frontend || return 1
-  genesis -C "frontend/output" -pkg frontend \
-    index.html \
-    elm.js \
-    main.js \
-    ble.js \
-    simple-iot-app-logo.png \
-    ports.js \
-    styles.css \
-    >assets/frontend/assets.go || return 1
-
-  genesis -C "assets/files" -pkg files \
-    dummy \
-    >assets/files/assets.go || return 1
   return 0
 }
 


### PR DESCRIPTION
* Removed installing go genesis.
* Removed the existing genesis file handler.
* Changed to go embed for file serving.
* Updated envsetup.sh to generate frontend within assets package.
* Had to generate within assets package because go embed does not support path traversing https://github.com/golang/go/issues/46056

Fixes https://github.com/simpleiot/simpleiot/issues/252