### PR TITLE
simpleiot-js bug fixes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,28 +2,20 @@ module.exports = {
   env: {
     browser: true,
     es6: true,
-    node: true
   },
   extends: "eslint:recommended",
-  parser: "babel-eslint",
   parserOptions: {
-    ecmaVersion: 6,
-    ecmaFeatures: {
-      experimentalObjectRestSpread: true,
-      jsx: true
-    },
+    ecmaVersion: 2018,
     sourceType: "module",
     allowImportExportEverywhere: true
   },
-  plugins: ["react"],
   rules: {
     "no-console": "off",
-    "react/jsx-uses-vars": 2,
     "accessor-pairs": "error",
     "array-bracket-spacing": ["error", "never"],
     "array-callback-return": "error",
     "arrow-body-style": "off",
-    "arrow-parens": ["error", "as-needed"],
+    "arrow-parens": ["error", "always"],
     "arrow-spacing": [
       "error",
       {
@@ -36,9 +28,13 @@ module.exports = {
     "brace-style": ["error", "1tbs"],
     "callback-return": "error",
     camelcase: "error",
-    "capitalized-comments": ["error", "never"],
     // "class-methods-use-this": "error",
-    "comma-dangle": "error",
+    "comma-dangle": ["error", {
+      "arrays": "only-multiline",
+      "objects": "only-multiline",
+      "imports": "only-multiline",
+      "exports": "only-multiline",
+    }],
     "comma-spacing": [
       "error",
       {
@@ -60,7 +56,6 @@ module.exports = {
     "func-call-spacing": "error",
     "func-name-matching": "error",
     "func-names": "error",
-    "func-style": ["error", "expression"],
     "generator-star-spacing": "error",
     "global-require": "error",
     "guard-for-in": "off",
@@ -176,7 +171,6 @@ module.exports = {
     "no-unmodified-loop-condition": "error",
     "no-unneeded-ternary": "error",
     "no-unused-expressions": "error",
-    "no-use-before-define": "error",
     "no-useless-call": "error",
     "no-useless-computed-key": "error",
     "no-useless-concat": "error",

--- a/frontend/lib/package-lock.json
+++ b/frontend/lib/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simpleiot-js",
-  "version": "1.0.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "simpleiot-js",
-      "version": "1.0.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "google-protobuf": "^3.20.1",

--- a/frontend/lib/package.json
+++ b/frontend/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simpleiot-js",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "SimpleIOT JavaScript API using NATS / WebSockets",
   "main": "siot-nats.js",
   "scripts": {

--- a/frontend/lib/siot-nats.js
+++ b/frontend/lib/siot-nats.js
@@ -23,7 +23,9 @@ export async function connect(opts = {}) {
 }
 
 // SIOTConnection is a wrapper around a NatsConnectionImpl
-function SIOTConnection() {}
+function SIOTConnection() {
+  // do nothing
+}
 
 Object.assign(SIOTConnection.prototype, {
   // getNode sends a request to `node.<id>` to retrieve an array of NodeEdges for
@@ -74,7 +76,8 @@ Object.assign(SIOTConnection.prototype, {
               opts,
               _cache,
             }));
-          _cache[n.id] = children; // update cache
+          // update cache
+          _cache[n.id] = children;
           if (!flat) {
             // If not flattening, add `children` key to `n`
             n.children = children;
@@ -210,12 +213,12 @@ Object.assign(SIOTConnection.prototype, {
 // decodeNodesRequest decodes a protobuf-encoded NodesRequest and returns
 // the array of nodes returned by the request
 function decodeNodesRequest(data) {
-  const { nodes, error } = NodesRequest.deserializeBinary(data).toObject();
+  const { nodesList, error } = NodesRequest.deserializeBinary(data).toObject();
   if (error) {
     throw new Error("NodesRequest decode error: " + error);
   }
 
-  for (const n of nodes) {
+  for (const n of nodesList) {
     // Convert `time` to JavaScript date for each point
     for (const p of n.pointsList) {
       p.time = new Date(p.time.seconds * 1e3 + p.time.nanos / 1e6);
@@ -224,7 +227,7 @@ function decodeNodesRequest(data) {
       p.time = new Date(p.time.seconds * 1e3 + p.time.nanos / 1e6);
     }
   }
-  return nodes;
+  return nodesList;
 }
 
 // encodePoints returns protobuf encoded Points
@@ -235,7 +238,8 @@ function encodePoints(points) {
     if (p instanceof Point) {
       return p;
     }
-    let { time, type, key, index, value, text, tombstone, data } = p;
+    let { time } = p;
+    const { type, key, index, value, text, tombstone, data } = p;
     p = new Point();
     if (!(time instanceof Timestamp)) {
       let { seconds, nanos } = time;


### PR DESCRIPTION
I also changed some of the eslint rules. Here's why:

- React isn't in this project, so that was removed
- We don't need the special babel parser either. Just use ES2018 (which now has widespread browser support)
- Changed `arrow-parens` and `comma-dangle` to match what prettier does
- `capitalized-comments`, `func-style`, and `no-use-before-define` seem excessive. Some of these can hurt readability in my opinion. I can understand the intent of these rules since JS has weird variable hoisting rules, but even if they aren't well understood by most devs, they rarely cause an issue these days with the advent of `let` and `const` keywords. Also, redefined variables / namespace clobbering are issues caught by a modern linter.

Going forward, I'd recommend using prettier. The biggest change would be converting from space indentation to tabs. @cbrake - Thoughts on this?