### PR TITLE
Changes relating to simpleiot-js frontend library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ For more details or to discuss releases, please visit the
   - write tests for sync
 - implement `siot log` subcommand -- this dumps SIOT messages
 - implement `siot store` subcommand -- used to check and fix store
+- simpleiot-js frontend library changes
+  - re-worked to use updated NATS API
+  - added `sendEdgePoints` API function
+  - added unit tests, linting, etc.
 
 ## [[0.5.5] - 2022-10-31](https://github.com/simpleiot/simpleiot/releases/tag/v0.5.5)
 

--- a/envsetup.sh
+++ b/envsetup.sh
@@ -149,16 +149,20 @@ siot_test_frontend() {
 }
 
 siot_test_frontend_lib() {
+  (cd ./frontend/lib && npm run lint || return 1) || return 1
   echo "Starting SimpleIOT..."
   ./siot serve --store siot_test_frontend_lib.sqlite --resetStore 2> /dev/null &
   PID=$!
   sleep 1
   (cd ./frontend/lib && npm run test || return 1)
+  CODE=$?
   echo "Stopping SimpleIOT..."
   kill -s SIGINT $PID
   wait $PID
   echo "SimpleIOT Stopped"
-  rm siot_test_frontend_lib.sqlite
+  if [ "$CODE" = "0" ]; then
+    rm siot_test_frontend_lib.sqlite
+  fi
 }
 
 # please run the following before pushing -- best if your editor can be set up
@@ -213,5 +217,9 @@ siot_goreleaser_release() {
 # - Ctrl+H,J,K,L move to panel left,below,above,right
 # see more keybindings here: https://github.com/danvergara/dblab#key-bindings
 siot_dblab() {
-  go run github.com/danvergara/dblab@latest --db siot.sqlite --driver sqlite3
+  STORE=siot.sqlite
+  if [ "$1" != "" ]; then
+    STORE=$1
+  fi
+  go run github.com/danvergara/dblab@latest --db $STORE --driver sqlite3
 }


### PR DESCRIPTION
Updated CHANGELOG
simpleiot-js:
  - `getNodeChildren` runs recursion serially to utilize cache
  - added `sendEdgePoints` API function
  - added test for creating a node
  - added test for pub/sub node points

envsetup:
  - simpleiot-js tests now run linter and preserves store on error
  - `siot_dblab` now accepts store parameter