### PR TITLE
Upgraded Point encoder to support many more types

### DIFF
--- a/client/manager.go
+++ b/client/manager.go
@@ -40,8 +40,7 @@ type Manager[T any] struct {
 func NewManager[T any](nc *nats.Conn,
 	construct func(nc *nats.Conn, config T) Client) *Manager[T] {
 	var x T
-	nodeType := reflect.TypeOf(x).Name()
-	nodeType = strings.ToLower(nodeType[0:1]) + nodeType[1:]
+	nodeType := data.ToCamelCase(reflect.TypeOf(x).Name())
 
 	return &Manager[T]{
 		nc:           nc,

--- a/client/node.go
+++ b/client/node.go
@@ -66,8 +66,7 @@ func GetNodes(nc *nats.Conn, parent, id, typ string, includeDel bool) ([]data.No
 // Deleted nodes are not included.
 func GetNodesType[T any](nc *nats.Conn, parent, id string) ([]T, error) {
 	var x T
-	nodeType := reflect.TypeOf(x).Name()
-	nodeType = strings.ToLower(nodeType[0:1]) + nodeType[1:]
+	nodeType := data.ToCamelCase(reflect.TypeOf(x).Name())
 
 	nodes, err := GetNodes(nc, parent, id, nodeType, false)
 

--- a/client/node.go
+++ b/client/node.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"reflect"
-	"strings"
 	"time"
 
 	"github.com/google/uuid"

--- a/data/decode.go
+++ b/data/decode.go
@@ -74,6 +74,10 @@ func (g GroupedPoints) SetValue(v reflect.Value) error {
 				len(g.Points), maxStructureSize,
 			)
 		}
+		// Ensure points are keyed
+		if !g.Keyed {
+			return fmt.Errorf("points missing Key")
+		}
 		// Ensure map is initialized
 		if v.IsNil() {
 			if !v.CanSet() {
@@ -93,6 +97,10 @@ func (g GroupedPoints) SetValue(v reflect.Value) error {
 			v.SetMapIndex(reflect.ValueOf(p.Key), vPtr.Elem())
 		}
 	case reflect.Struct:
+		// Ensure points are keyed
+		if !g.Keyed {
+			return fmt.Errorf("points missing Key")
+		}
 		// Create map of Points
 		values := make(map[string]Point, len(g.Points))
 		for _, p := range g.Points {

--- a/data/decode.go
+++ b/data/decode.go
@@ -1,8 +1,8 @@
 package data
 
 import (
-	"errors"
 	"fmt"
+	"log"
 	"reflect"
 )
 
@@ -11,6 +11,100 @@ import (
 type NodeEdgeChildren struct {
 	NodeEdge NodeEdge
 	Children []NodeEdgeChildren
+}
+
+type GroupedPoints struct {
+	Keyed    bool
+	IndexMax int
+	Points   []Point
+}
+
+var reflectValueT = reflect.TypeOf(reflect.Value{})
+
+func setValueFromPointGroup(g GroupedPoints, v reflect.Value) error {
+	t := v.Type()
+	switch k := t.Kind(); k {
+	case reflect.Array, reflect.Slice:
+		// Check array bounds
+		if g.IndexMax > maxStructureSize {
+			return fmt.Errorf(
+				"Point.Index %v exceeds %v",
+				g.IndexMax, maxStructureSize,
+			)
+		}
+		if k == reflect.Array && g.IndexMax > t.Len()-1 {
+			return fmt.Errorf(
+				"Point.Index %v exceeds array size %v",
+				g.IndexMax, t.Len(),
+			)
+		}
+		// Expand slice if needed
+		if k == reflect.Slice && g.IndexMax > v.Len()-1 {
+			if !v.CanSet() {
+				return fmt.Errorf("cannot set value %v", v)
+			}
+			newV := reflect.MakeSlice(t, g.IndexMax+1, g.IndexMax+1)
+			reflect.Copy(newV, v)
+			v.Set(newV)
+		}
+		// Set array / slice values
+		for _, p := range g.Points {
+			// Note: array / slice values are set directly on the indexed Value
+			setVal(p, v.Index(int(p.Index)))
+		}
+	case reflect.Map:
+		// Ensure map is keyed by string
+		if keyK := t.Key().Kind(); keyK != reflect.String {
+			return fmt.Errorf("cannot set map keyed by %v", keyK)
+		}
+		if len(g.Points) > maxStructureSize {
+			return fmt.Errorf(
+				"size of %v exceeds maximum of %v",
+				len(g.Points), maxStructureSize,
+			)
+		}
+		// Ensure map is initialized
+		if v.IsNil() {
+			if !v.CanSet() {
+				return fmt.Errorf("cannot set value %v", v)
+			}
+			v.Set(reflect.MakeMapWithSize(t, len(g.Points)))
+		}
+		// Set map values
+		for _, p := range g.Points {
+			// Create and set a new map value
+			// Note: map values must be set on newly created Values
+			vPtr := reflect.New(t.Elem())
+			setVal(p, vPtr.Elem())
+			v.SetMapIndex(reflect.ValueOf(p.Key), vPtr.Elem())
+		}
+	case reflect.Struct:
+		// Create map of Points
+		values := make(map[string]Point, len(g.Points))
+		for _, p := range g.Points {
+			values[p.Key] = p
+		}
+		// Write points to struct
+		for numField, i := v.NumField(), 0; i < numField; i++ {
+			sf := t.Field(i)
+			key := sf.Tag.Get("point")
+			if key == "" {
+				key = sf.Tag.Get("edgepoint")
+			}
+			if key == "" {
+				key = ToCamelCase(sf.Name)
+			}
+			setVal(values[key], v.Field(i))
+		}
+	default:
+		if len(g.Points) > 1 {
+			log.Println("Decode warning, decoded multiple points to scalar")
+		}
+		for _, p := range g.Points {
+			setVal(p, v)
+		}
+	}
+	return nil
 }
 
 // Decode converts a Node to custom struct.
@@ -31,71 +125,117 @@ type NodeEdgeChildren struct {
 //
 // output can also be a *reflect.Value
 func Decode(input NodeEdgeChildren, output interface{}) error {
-	var vOut reflect.Value
-	var tOut reflect.Type
+	vOut := reflect.Indirect(reflect.ValueOf(output))
+	tOut := vOut.Type()
 
-	if reflect.TypeOf(output).String() == "*reflect.Value" {
-		outputV, ok := output.(*reflect.Value)
-		if !ok {
-			return errors.New("Error converting interface")
-		}
-
-		vOut = outputV.Elem()
-		tOut = outputV.Type().Elem()
-	} else {
-		vOut = reflect.ValueOf(output).Elem()
-		tOut = reflect.TypeOf(output).Elem()
+	if tOut == reflectValueT {
+		// `output` was a reflect.Value or *reflect.Value
+		vOut = vOut.Interface().(reflect.Value)
+		tOut = vOut.Type()
 	}
 
-	pointValues := make(map[string]reflect.Value)
-	edgeValues := make(map[string]reflect.Value)
-	childValues := make(map[string]reflect.Value)
+	if k := tOut.Kind(); k != reflect.Struct {
+		return fmt.Errorf("Error decoding to %v; must be a struct", k)
+	}
+
+	// Group points and children by type
+	pointGroups := make(map[string]GroupedPoints)
+	edgePointGroups := make(map[string]GroupedPoints)
+	childGroups := make(map[string][]NodeEdgeChildren)
+
+	for _, p := range input.NodeEdge.Points {
+		g, ok := pointGroups[p.Type]
+		if !ok {
+			g = GroupedPoints{}
+		}
+		if p.Key != "" {
+			g.Keyed = true
+		}
+		if index := int(p.Index); index > g.IndexMax {
+			g.IndexMax = index
+		}
+		g.Points = append(g.Points, p)
+		pointGroups[p.Type] = g
+	}
+	for _, p := range input.NodeEdge.EdgePoints {
+		g, ok := edgePointGroups[p.Type]
+		if !ok {
+			g = GroupedPoints{}
+		}
+		if p.Key != "" {
+			g.Keyed = true
+		}
+
+		if index := int(p.Index); index > g.IndexMax {
+			g.IndexMax = index
+		}
+		g.Points = append(g.Points, p)
+		edgePointGroups[p.Type] = g
+	}
+	for _, c := range input.Children {
+		childGroups[c.NodeEdge.Type] = append(childGroups[c.NodeEdge.Type], c)
+	}
 
 	for i := 0; i < tOut.NumField(); i++ {
 		sf := tOut.Field(i)
 		if pt := sf.Tag.Get("point"); pt != "" {
-			pointValues[pt] = vOut.Field(i)
+			g := pointGroups[pt]
+			// Write points into struct field
+			err := setValueFromPointGroup(g, vOut.Field(i))
+			if err != nil {
+				log.Printf("decode error for type %v: %v", pt, err)
+			}
 		} else if et := sf.Tag.Get("edgepoint"); et != "" {
-			edgeValues[et] = vOut.Field(i)
+			g := edgePointGroups[et]
+			// Write points into struct field
+			err := setValueFromPointGroup(g, vOut.Field(i))
+			if err != nil {
+				log.Printf("decode error for type %v: %v", et, err)
+			}
 		} else if nt := sf.Tag.Get("node"); nt != "" {
+			// Ensure field is a settable string
 			if nt == "id" {
-				vOut.Field(i).SetString(input.NodeEdge.ID)
+				v := vOut.Field(i)
+				if !v.CanSet() {
+					log.Printf("decode error for id: cannot set")
+					continue
+				}
+				if v.Kind() != reflect.String {
+					log.Printf("decode error for id: not a string")
+					continue
+				}
+				v.SetString(input.NodeEdge.ID)
 			} else if nt == "parent" {
-				vOut.Field(i).SetString(input.NodeEdge.Parent)
+				v := vOut.Field(i)
+				if !v.CanSet() {
+					log.Printf("decode error for parent: cannot set")
+					continue
+				}
+				if v.Kind() != reflect.String {
+					log.Printf("decode error for parent: not a string")
+					continue
+				}
+				v.SetString(input.NodeEdge.Parent)
 			}
 		} else if ct := sf.Tag.Get("child"); ct != "" {
-			childValues[ct] = vOut.Field(i)
-		}
-	}
+			g := childGroups[ct]
+			// Ensure field is a settable slice
+			v := vOut.Field(i)
+			t := v.Type()
+			if t.Kind() != reflect.Slice {
+				log.Printf("decode error for child %v: not a slice", ct)
+			}
+			if !v.CanSet() {
+				log.Printf("decode error for child %v: cannot set", ct)
+			}
 
-	for _, p := range input.NodeEdge.Points {
-		v, ok := pointValues[p.Type]
-		if ok {
-			setVal(p, v)
-		}
-	}
-
-	for _, p := range input.NodeEdge.EdgePoints {
-		v, ok := edgeValues[p.Type]
-		if ok {
-			setVal(p, v)
-		}
-	}
-
-	for _, c := range input.Children {
-		for k, v := range childValues {
-			// v is an array
-			if c.NodeEdge.Type == k {
-				// get an empty value of the type of the array
-				cOut := reflect.New(v.Type().Elem())
-
-				err := Decode(c, &cOut)
+			// Initialize slice
+			v.Set(reflect.MakeSlice(t, len(g), len(g)))
+			for i, child := range childGroups[ct] {
+				err := Decode(child, v.Index(i))
 				if err != nil {
-					return fmt.Errorf("Error decoding child: %v", err)
+					log.Printf("decode error for child %v: %v", ct, err)
 				}
-
-				// append the new value to the child array
-				childValues[k].Set(reflect.Append(v, cOut.Elem()))
 			}
 		}
 	}

--- a/data/encode.go
+++ b/data/encode.go
@@ -77,9 +77,8 @@ func appendPointsFromValue(
 		}
 	case reflect.Map:
 		// Points support maps with string keys
-		kKey := t.Key().Kind()
-		if kKey != reflect.String {
-			return points, fmt.Errorf("unsupported type: map keyed by %v", kKey)
+		if keyK := t.Key().Kind(); keyK != reflect.String {
+			return points, fmt.Errorf("unsupported type: map keyed by %v", keyK)
 		}
 		if v.Len() > maxStructureSize {
 			return points, fmt.Errorf(

--- a/data/encode_decode_test.go
+++ b/data/encode_decode_test.go
@@ -108,6 +108,68 @@ func TestEncodeCase(t *testing.T) {
 	}
 }
 
+type TestType2 struct {
+	ID          string            `node:"id"`
+	Parent      string            `node:"parent"`
+	Description string            `point:"description"`
+	IPAddresses []string          `point:"ipAddress"`
+	Location    map[string]string `point:"location"`
+	Sensors     map[string]int    `point:"sensor"`
+	Nested      TestType          `point:"nested"`
+	TestValues  []int32           `edgepoint:"testValue"`
+	Tombstone   bool              `edgepoint:"tombstone"`
+}
+
+var nodeEdgeTest2 = NodeEdge{
+	ID:     "123",
+	Parent: "456",
+	Type:   "testType2",
+	Points: []Point{
+		{Type: "description", Text: "hi there"},
+		{Type: "ipAddress", Index: 0, Text: "192.168.1.1"},
+		{Type: "ipAddress", Index: 1, Text: "127.0.0.1"},
+		{Type: "location", Key: "hello", Text: "world"},
+		{Type: "location", Key: "goodbye", Text: "cruel world"},
+		{Type: "sensor", Key: "temp1", Value: 23},
+		{Type: "sensor", Key: "temp2", Value: 40},
+		{Type: "nested", Key: "id", Text: "789"},
+		{Type: "nested", Key: "parent", Text: "456"},
+		{Type: "nested", Key: "description", Text: "nested test type"},
+	},
+	EdgePoints: []Point{
+		{Type: "testValue", Index: 0, Value: 314},
+		{Type: "testValue", Index: 1, Value: 1024},
+		{Type: "tombstone", Value: 1},
+	},
+}
+
+func TestEncodeComplex(t *testing.T) {
+	test := TestType2{"123", "456", "hi there",
+		[]string{"192.168.1.1", "127.0.0.1"},
+		map[string]string{
+			"hello":   "world",
+			"goodbye": "cruel world",
+		},
+		map[string]int{
+			"temp1": 23,
+			"temp2": 40,
+		},
+		TestType{"789", "456", "nested test type"},
+		[]int32{314, 1024},
+		true,
+	}
+
+	ne, err := Encode(test)
+
+	if err != nil {
+		t.Fatal("encode failed:", err)
+	}
+
+	if !reflect.DeepEqual(ne, nodeEdgeTest2) {
+		t.Errorf("Decode failed, exp: %v, got %v", nodeEdgeTest2, ne)
+	}
+}
+
 type testX struct {
 	ID          string  `node:"id"`
 	Parent      string  `node:"parent"`


### PR DESCRIPTION
As discussed previously, this PR will allow Points to be encoded / decoded to / from many more Go types, including arrays, maps, and "flat" structs.