### PR TITLE
Reworked and simplified decode and merge routines

### DIFF
--- a/data/decode.go
+++ b/data/decode.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 	"log"
 	"reflect"
-	"slices"
 	"strconv"
+
+	"golang.org/x/exp/slices"
 )
 
 // NodeEdgeChildren is used to pass a tree node structure into the

--- a/data/decode.go
+++ b/data/decode.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"reflect"
+	"slices"
 	"strconv"
 )
 
@@ -18,16 +19,25 @@ type NodeEdgeChildren struct {
 // reflectValueT is the `reflect.Type` for a `reflect.Value`
 var reflectValueT = reflect.TypeOf(reflect.Value{})
 
-// GroupedPoints are Points grouped by the `Point.Type`. While scanning
+// GroupedPoints are Points grouped by their `Point.Type`. While scanning
 // through the list of points, we also keep track of whether or not the
-// points have an Index or Key
+// points are keyed with positive integer values (for decoding into arrays)
 type GroupedPoints struct {
-	// Keyed if and only if a Point's `Key` field is populated
-	Keyed bool
-	// IndexMax is the largest `Point.Index` value in Points
-	IndexMax int
+	// KeyNotIndex is set to a Point's `Key` field if it *cannot* be parsed as a
+	// positive integer
+	// Note: If `Key` is empty string (""), it is treated as "0"
+	KeyNotIndex string
+	// KeyMaxInt is the largest `Point.Key` value in Points
+	KeyMaxInt int
 	// Points is the list of Points for this group
 	Points []Point
+
+	// TODO: We can also simultaneously implement sorting floating point keys
+	// KeysNumeric is set if and only if each Point's `Key` field is numeric
+	// and can be parsed as a float64
+	// KeysNumeric bool
+	// KeyMaxFloat is the largest `Point.Key` value in Points
+	// KeyMaxFloat float64
 }
 
 // SetValue populates v with the Points in the group
@@ -35,50 +45,68 @@ func (g GroupedPoints) SetValue(v reflect.Value) error {
 	t := v.Type()
 	switch k := t.Kind(); k {
 	case reflect.Array, reflect.Slice:
-		// Check array bounds
-		if g.IndexMax > maxStructureSize {
+		// Ensure all keys are array indexes
+		if g.KeyNotIndex != "" {
 			return fmt.Errorf(
-				"Point.Index %v exceeds %v",
-				g.IndexMax, maxStructureSize,
+				"Point.Key %v is not a valid index",
+				g.KeyNotIndex,
 			)
 		}
-		if k == reflect.Array && g.IndexMax > t.Len()-1 {
+		// Check array bounds
+		if g.KeyMaxInt > maxStructureSize {
 			return fmt.Errorf(
-				"Point.Index %v exceeds array size %v",
-				g.IndexMax, t.Len(),
+				"Point.Key %v exceeds %v",
+				g.KeyMaxInt, maxStructureSize,
+			)
+		}
+		if k == reflect.Array && g.KeyMaxInt > t.Len()-1 {
+			return fmt.Errorf(
+				"Point.Key %v exceeds array size %v",
+				g.KeyMaxInt, t.Len(),
 			)
 		}
 		// Expand slice if needed
-		if k == reflect.Slice && g.IndexMax > v.Len()-1 {
+		if k == reflect.Slice && g.KeyMaxInt > v.Len()-1 {
 			if !v.CanSet() {
 				return fmt.Errorf("cannot set value %v", v)
 			}
-			newV := reflect.MakeSlice(t, g.IndexMax+1, g.IndexMax+1)
+			newV := reflect.MakeSlice(t, g.KeyMaxInt+1, g.KeyMaxInt+1)
 			reflect.Copy(newV, v)
 			v.Set(newV)
 		}
 		// Set array / slice values
+		deletedIndexes := []int{}
 		for _, p := range g.Points {
 			// Note: array / slice values are set directly on the indexed Value
 			index, _ := strconv.Atoi(p.Key)
-			if p.Tombstone == 1 {
-				// assume the entire array is written, so if there are
-				// tombstone points sent, simply remove the last entry
-				// in the array as a point to remove previous entries
-				// may be sent first.
-				newLen := v.Len() - 1
-				newSlice := reflect.MakeSlice(v.Type(), newLen, newLen)
-				for i := 0; i < newLen; i++ {
-					newSlice.Index(i).Set(v.Index(i))
-				}
-				v.Set(newSlice)
-			} else {
-				err := setVal(p, v.Index(index))
-				if err != nil {
-					return err
+			if p.Tombstone%2 == 1 {
+				deletedIndexes = append(deletedIndexes, index)
+				// Ignore this deleted value if it won't fit in the slice anyway
+				// Note: KeyMaxInt is not set for points with Tombstone set, so
+				// index could still be out of range.
+				if index >= v.Len() {
+					continue
 				}
 			}
+			// Finally, set the value in the slice
+			err := setVal(p, v.Index(index))
+			if err != nil {
+				return err
+			}
 		}
+		// We can now trim the underlying slice to remove trailing values that
+		// were deleted in this decode. Note: this does not guarantee that
+		// slices are always trimmed properly because values can be deleted
+		// across multiple decode cycles.
+		slices.Sort(deletedIndexes)
+		lastIndex := v.Len() - 1
+		for i := len(deletedIndexes) - 1; i >= 0; i-- {
+			if deletedIndexes[i] != lastIndex {
+				break
+			}
+			lastIndex--
+		}
+		v.Set(v.Slice(0, lastIndex+1))
 	case reflect.Map:
 		// Ensure map is keyed by string
 		if keyK := t.Key().Kind(); keyK != reflect.String {
@@ -86,14 +114,16 @@ func (g GroupedPoints) SetValue(v reflect.Value) error {
 		}
 		if len(g.Points) > maxStructureSize {
 			return fmt.Errorf(
-				"size of %v exceeds maximum of %v",
+				"number of points %v exceeds maximum of %v for a map",
 				len(g.Points), maxStructureSize,
 			)
 		}
 		// Ensure points are keyed
-		if !g.Keyed {
-			return fmt.Errorf("points missing Key")
-		}
+		// Note: No longer relevant, as all points as keyed now
+		// if !g.Keyed {
+		// 	return fmt.Errorf("points missing Key")
+		// }
+
 		// Ensure map is initialized
 		if v.IsNil() {
 			if !v.CanSet() {
@@ -103,31 +133,28 @@ func (g GroupedPoints) SetValue(v reflect.Value) error {
 		}
 		// Set map values
 		for _, p := range g.Points {
-			if p.Tombstone == 1 {
-				newMap := reflect.MakeMap(v.Type())
-				iter := v.MapRange()
-				for iter.Next() {
-					if !reflect.DeepEqual(iter.Key().Interface(), p.Key) {
-						newMap.SetMapIndex(iter.Key(), iter.Value())
-					}
-				}
-				v.Set(newMap)
+			// Enforce valid Key value
+			key := p.Key
+			if key == "" {
+				key = "0"
+			}
+			if p.Tombstone%2 == 1 {
+				// We want to delete the map entry if Tombstone is set
+				v.SetMapIndex(reflect.ValueOf(key), reflect.Value{})
 			} else {
 				// Create and set a new map value
 				// Note: map values must be set on newly created Values
-				vPtr := reflect.New(t.Elem())
-				err := setVal(p, vPtr.Elem())
+				// because (unlike arrays / slices) any value returned by
+				// `MapIndex` is not settable
+				newV := reflect.New(t.Elem()).Elem()
+				err := setVal(p, newV)
 				if err != nil {
 					return err
 				}
-				v.SetMapIndex(reflect.ValueOf(p.Key), vPtr.Elem())
+				v.SetMapIndex(reflect.ValueOf(key), newV)
 			}
 		}
 	case reflect.Struct:
-		// Ensure points are keyed
-		if !g.Keyed {
-			return fmt.Errorf("points missing Key")
-		}
 		// Create map of Points
 		values := make(map[string]Point, len(g.Points))
 		for _, p := range g.Points {
@@ -143,6 +170,10 @@ func (g GroupedPoints) SetValue(v reflect.Value) error {
 			if key == "" {
 				key = ToCamelCase(sf.Name)
 			}
+			// Ensure points are keyed
+			if key == "" {
+				return fmt.Errorf("point missing Key")
+			}
 			err := setVal(values[key], v.Field(i))
 			if err != nil {
 				return err
@@ -150,7 +181,12 @@ func (g GroupedPoints) SetValue(v reflect.Value) error {
 		}
 	default:
 		if len(g.Points) > 1 {
-			log.Printf("Decode warning, decoded multiple points to %v:\n%v", t, Points(g.Points))
+			log.Printf(
+				"Decode warning, decoded multiple points to %v:\n%v",
+				// Cast to `Points` type with a `String()` method which prints
+				// a trailing newline
+				t, Points(g.Points),
+			)
 		}
 		for _, p := range g.Points {
 			err := setVal(p, v)
@@ -178,21 +214,13 @@ func (g GroupedPoints) SetValue(v reflect.Value) error {
 //		Conditions  []Condition `child:"condition"`
 //	   }
 //
-// output can also be a *reflect.Value
-func Decode(input NodeEdgeChildren, output interface{}) error {
+// outputStruct can also be a *reflect.Value
+func Decode(input NodeEdgeChildren, outputStruct interface{}) error {
+	outV, outT, outK := reflectValue(outputStruct)
+	if outK != reflect.Struct {
+		return fmt.Errorf("error decoding to %v; must be a struct", outK)
+	}
 	var retErr error
-	vOut := reflect.Indirect(reflect.ValueOf(output))
-	tOut := vOut.Type()
-
-	if tOut == reflectValueT {
-		// `output` was a reflect.Value or *reflect.Value
-		vOut = vOut.Interface().(reflect.Value)
-		tOut = vOut.Type()
-	}
-
-	if k := tOut.Kind(); k != reflect.Struct {
-		return fmt.Errorf("Error decoding to %v; must be a struct", k)
-	}
 
 	// Group points and children by type
 	pointGroups := make(map[string]GroupedPoints)
@@ -201,39 +229,33 @@ func Decode(input NodeEdgeChildren, output interface{}) error {
 
 	// we first collect all points into groups by type
 	// this is required in case we are decoding into a map or array
+	// Note: Even points with tombstones set are processed here; later we set
+	// the destination to the zero value if a tombstone is present.
 	for _, p := range input.NodeEdge.Points {
-		if p.Tombstone == 1 {
-			continue
-		}
-		g, ok := pointGroups[p.Type]
-		if !ok {
-			g = GroupedPoints{}
-		}
+		g := pointGroups[p.Type] // uses zero value if not found
 		if p.Key != "" {
-			g.Keyed = true
+			index, err := strconv.Atoi(p.Key)
+			if err != nil || index < 0 {
+				g.KeyNotIndex = p.Key
+			} else if index > g.KeyMaxInt && p.Tombstone%2 == 0 {
+				// Note: Do not set `KeyMaxInt` if Tombstone is set. We don't
+				// need to expand the slice in this case.
+				g.KeyMaxInt = index
+			}
 		}
-		index, _ := strconv.Atoi(p.Key)
-		if index > g.IndexMax {
-			g.IndexMax = index
-		}
+		// else p.Key is treated like "0"; no need to update `g` at all
 		g.Points = append(g.Points, p)
 		pointGroups[p.Type] = g
 	}
 	for _, p := range input.NodeEdge.EdgePoints {
-		if p.Tombstone == 1 {
-			continue
-		}
-		g, ok := edgePointGroups[p.Type]
-		if !ok {
-			g = GroupedPoints{}
-		}
+		g := edgePointGroups[p.Type]
 		if p.Key != "" {
-			g.Keyed = true
-		}
-
-		index, _ := strconv.Atoi(p.Key)
-		if index > g.IndexMax {
-			g.IndexMax = index
+			index, err := strconv.Atoi(p.Key)
+			if err != nil || index < 0 {
+				g.KeyNotIndex = p.Key
+			} else if index > g.KeyMaxInt && p.Tombstone%2 == 0 {
+				g.KeyMaxInt = index
+			}
 		}
 		g.Points = append(g.Points, p)
 		edgePointGroups[p.Type] = g
@@ -243,49 +265,61 @@ func Decode(input NodeEdgeChildren, output interface{}) error {
 	}
 
 	// now process the fields in the output struct
-	for i := 0; i < tOut.NumField(); i++ {
-		sf := tOut.Field(i)
+	for i := 0; i < outT.NumField(); i++ {
+		sf := outT.Field(i)
 		// look at tags to determine if we have a point, edgepoint, node attribute, or child node
 		if pt := sf.Tag.Get("point"); pt != "" {
 			// see if we have any points for this field point type
 			g, ok := pointGroups[pt]
 			if ok {
 				// Write points into struct field
-				err := g.SetValue(vOut.Field(i))
+				err := g.SetValue(outV.Field(i))
 				if err != nil {
-					retErr = errors.Join(retErr, fmt.Errorf("decode error for type %v: %w", pt, err))
+					retErr = errors.Join(retErr, fmt.Errorf(
+						"decode error for type %v: %w", pt, err,
+					))
 				}
 			}
 		} else if et := sf.Tag.Get("edgepoint"); et != "" {
 			g, ok := edgePointGroups[et]
 			if ok {
 				// Write points into struct field
-				err := g.SetValue(vOut.Field(i))
+				err := g.SetValue(outV.Field(i))
 				if err != nil {
-					retErr = errors.Join(err, fmt.Errorf("decode error for type %v: %w", et, err))
+					retErr = errors.Join(retErr, fmt.Errorf(
+						"decode error for type %v: %w", et, err,
+					))
 				}
 			}
 		} else if nt := sf.Tag.Get("node"); nt != "" {
-			// Ensure field is a settable string
-			if nt == "id" {
-				v := vOut.Field(i)
+			// Set ID or Parent field where appropriate
+			if nt == "id" && input.NodeEdge.ID != "" {
+				v := outV.Field(i)
 				if !v.CanSet() {
-					retErr = errors.Join(retErr, fmt.Errorf("decode error for id: cannot set"))
+					retErr = errors.Join(retErr, fmt.Errorf(
+						"decode error for id: cannot set",
+					))
 					continue
 				}
 				if v.Kind() != reflect.String {
-					retErr = errors.Join(retErr, fmt.Errorf("decode error for id: not a string"))
+					retErr = errors.Join(retErr, fmt.Errorf(
+						"decode error for id: not a string",
+					))
 					continue
 				}
 				v.SetString(input.NodeEdge.ID)
-			} else if nt == "parent" {
-				v := vOut.Field(i)
+			} else if nt == "parent" && input.NodeEdge.Parent != "" {
+				v := outV.Field(i)
 				if !v.CanSet() {
-					retErr = errors.Join(retErr, fmt.Errorf("decode error for parent: cannot set"))
+					retErr = errors.Join(retErr, fmt.Errorf(
+						"decode error for parent: cannot set",
+					))
 					continue
 				}
 				if v.Kind() != reflect.String {
-					retErr = errors.Join(retErr, fmt.Errorf("decode error for parent: not a string"))
+					retErr = errors.Join(retErr, fmt.Errorf(
+						"decode error for parent: not a string",
+					))
 					continue
 				}
 				v.SetString(input.NodeEdge.Parent)
@@ -294,21 +328,29 @@ func Decode(input NodeEdgeChildren, output interface{}) error {
 			g, ok := childGroups[ct]
 			if ok {
 				// Ensure field is a settable slice
-				v := vOut.Field(i)
+				v := outV.Field(i)
 				t := v.Type()
 				if t.Kind() != reflect.Slice {
-					retErr = errors.Join(retErr, fmt.Errorf("decode error for child %v: not a slice", ct))
+					retErr = errors.Join(retErr, fmt.Errorf(
+						"decode error for child %v: not a slice", ct,
+					))
+					continue
 				}
 				if !v.CanSet() {
-					retErr = errors.Join(retErr, fmt.Errorf("decode error for child %v: cannot set", ct))
+					retErr = errors.Join(retErr, fmt.Errorf(
+						"decode error for child %v: cannot set", ct,
+					))
+					continue
 				}
 
 				// Initialize slice
 				v.Set(reflect.MakeSlice(t, len(g), len(g)))
-				for i, child := range childGroups[ct] {
+				for i, child := range g {
 					err := Decode(child, v.Index(i))
 					if err != nil {
-						retErr = errors.Join(retErr, fmt.Errorf("decode error for child %v: %v", ct, err))
+						retErr = errors.Join(retErr, fmt.Errorf(
+							"decode error for child %v: %w", ct, err,
+						))
 					}
 				}
 			}
@@ -316,4 +358,67 @@ func Decode(input NodeEdgeChildren, output interface{}) error {
 	}
 
 	return retErr
+}
+
+// setVal writes a scalar Point value / text to a reflect.Value
+// Supports boolean, integer, floating point, and string destinations
+// Writes the zero value to `v` if the Point has an odd Tombstone value
+func setVal(p Point, v reflect.Value) error {
+	if !v.CanSet() {
+		return fmt.Errorf("cannot set value")
+	}
+	if p.Tombstone%2 == 1 {
+		// Set to zero value
+		v.Set(reflect.Zero(v.Type()))
+		return nil
+	}
+	switch k := v.Kind(); k {
+	case reflect.Bool:
+		v.SetBool(FloatToBool(p.Value))
+	case reflect.Int,
+		reflect.Int8,
+		reflect.Int16,
+		reflect.Int32,
+		reflect.Int64:
+
+		if v.OverflowInt(int64(p.Value)) {
+			return fmt.Errorf("int overflow: %v", p.Value)
+		}
+		v.SetInt(int64(p.Value))
+	case reflect.Uint,
+		reflect.Uint8,
+		reflect.Uint16,
+		reflect.Uint32,
+		reflect.Uint64:
+
+		if p.Value < 0 || v.OverflowUint(uint64(p.Value)) {
+			return fmt.Errorf("uint overflow: %v", p.Value)
+		}
+		v.SetUint(uint64(p.Value))
+	case reflect.Float32, reflect.Float64:
+		v.SetFloat(p.Value)
+	case reflect.String:
+		v.SetString(p.Text)
+	default:
+		return fmt.Errorf("unsupported type: %v", k)
+	}
+	return nil
+}
+
+// reflectValue returns a reflect.Value from an interface
+// This function dereferences `output` if it's a pointer or a reflect.Value
+func reflectValue(output interface{}) (
+	outV reflect.Value, outT reflect.Type, outK reflect.Kind,
+) {
+	outV = reflect.Indirect(reflect.ValueOf(output))
+	outT = outV.Type()
+
+	if outT == reflectValueT {
+		// `output` was a reflect.Value or *reflect.Value
+		outV = outV.Interface().(reflect.Value)
+		outT = outV.Type()
+	}
+
+	outK = outT.Kind()
+	return
 }

--- a/data/merge.go
+++ b/data/merge.go
@@ -1,48 +1,67 @@
 package data
 
 import (
-	"errors"
 	"fmt"
 	"reflect"
-	"strconv"
 )
 
-// setVal writes a scalar Point value / text to a reflect.Value
-func setVal(p Point, v reflect.Value) error {
-	if !v.CanSet() {
-		return fmt.Errorf("cannot set value")
+// FindNodeInStruct recursively scans the `outputStruct` for a struct
+// with a field having a `node:"id"` tag and whose value matches `nodeID`.
+// If `parentID` is provided, the struct must also have a field with a
+// `node:"parent"` tag whose value matches `parentID`. If such a struct is
+// found, the struct is returned as a reflect.Value; otherwise, an invalid
+// reflect.Value is returned whose IsValid method returns false.
+func FindNodeInStruct(outputStruct interface{}, nodeID string, parentID string) reflect.Value {
+	// If `nodeID` is not provided, we abort immediately
+	if nodeID == "" {
+		return reflect.Value{}
 	}
-	switch k := v.Kind(); k {
-	case reflect.Bool:
-		v.SetBool(FloatToBool(p.Value))
-	case reflect.Int,
-		reflect.Int8,
-		reflect.Int16,
-		reflect.Int32,
-		reflect.Int64:
 
-		if v.OverflowInt(int64(p.Value)) {
-			return fmt.Errorf("int overflow: %v", p.Value)
-		}
-		v.SetInt(int64(p.Value))
-	case reflect.Uint,
-		reflect.Uint8,
-		reflect.Uint16,
-		reflect.Uint32,
-		reflect.Uint64:
-
-		if p.Value < 0 || v.OverflowUint(uint64(p.Value)) {
-			return fmt.Errorf("int overflow: %v", p.Value)
-		}
-		v.SetUint(uint64(p.Value))
-	case reflect.Float32, reflect.Float64:
-		v.SetFloat(p.Value)
-	case reflect.String:
-		v.SetString(p.Text)
-	default:
-		return fmt.Errorf("unsupported type: %v", k)
+	outV, outT, outK := reflectValue(outputStruct)
+	if outK != reflect.Struct {
+		return reflect.Value{}
 	}
-	return nil
+
+	// Scan struct fields
+	outID := ""
+	outParentID := ""
+	childValues := make(map[string]reflect.Value)
+
+	for i := 0; i < outT.NumField(); i++ {
+		sf := outT.Field(i)
+		if nt := sf.Tag.Get("node"); nt != "" {
+			if nt == "id" {
+				outID = outV.Field(i).String()
+			} else if nt == "parent" {
+				outParentID = outV.Field(i).String()
+			}
+		} else if ct := sf.Tag.Get("child"); ct != "" &&
+			sf.Type.Kind() == reflect.Slice {
+			childValues[ct] = outV.Field(i)
+		}
+	}
+
+	if parentID == "" {
+		if outID == nodeID {
+			return outV // found it
+		}
+	} else if outID == nodeID && outParentID == parentID {
+		return outV // found it
+	}
+
+	// `outV` does not match; scan all children recursively
+	for _, c := range childValues {
+		// Note: `c` was already checked to ensure it's a slice
+		for i, length := 0, c.Len(); i < length; i++ {
+			childVal := FindNodeInStruct(c.Index(i), nodeID, parentID)
+			if childVal.IsValid() {
+				return childVal // found it
+			}
+		}
+	}
+
+	// Not found; return invalid value
+	return reflect.Value{}
 }
 
 // MergePoints takes points and updates fields in a type
@@ -51,176 +70,35 @@ func setVal(p Point, v reflect.Value) error {
 // and the last entry from the array is removed. Normally, it is recommended
 // to send all points for an array when doing complex modifications to
 // an array.
-func MergePoints(id string, points []Point, output interface{}) error {
-	// TODO: this is not the most efficient algorithm as it recurses into
-	// all child arrays looking for a struct id
-
-	var retErr error
-	vOut := reflect.Indirect(reflect.ValueOf(output))
-	tOut := vOut.Type()
-
-	if tOut == reflectValueT {
-		// `output` was a reflect.Value or *reflect.Value
-		vOut = vOut.Interface().(reflect.Value)
-		tOut = vOut.Type()
+func MergePoints(id string, points []Point, outputStruct interface{}) error {
+	outV := FindNodeInStruct(outputStruct, id, "")
+	if !outV.IsValid() {
+		return fmt.Errorf(
+			"no matching struct with a `node:\"id\"` field matching %v", id,
+		)
 	}
 
-	if k := tOut.Kind(); k != reflect.Struct {
-		return fmt.Errorf("Error decoding to %v; must be a struct", k)
+	ne := NodeEdge{
+		ID:     id,
+		Points: points,
 	}
-
-	pointGroups := make(map[string]GroupedPoints)
-
-	for _, p := range points {
-		g, ok := pointGroups[p.Type]
-		if !ok {
-			g = GroupedPoints{}
-		}
-		if p.Key != "" {
-			g.Keyed = true
-		}
-
-		index, _ := strconv.Atoi(p.Key)
-		if index > g.IndexMax {
-			g.IndexMax = index
-		}
-		g.Points = append(g.Points, p)
-		pointGroups[p.Type] = g
-	}
-
-	pointValues := make(map[string]reflect.Value)
-	childValues := make(map[string]reflect.Value)
-
-	structID := ""
-
-	for i := 0; i < tOut.NumField(); i++ {
-		sf := tOut.Field(i)
-		if pt := sf.Tag.Get("point"); pt != "" {
-			pointValues[pt] = vOut.Field(i)
-		} else if nt := sf.Tag.Get("node"); nt != "" {
-			if nt == "id" {
-				structID = vOut.Field(i).String()
-			}
-		} else if ct := sf.Tag.Get("child"); ct != "" {
-			childValues[ct] = vOut.Field(i)
-		}
-	}
-
-	if structID == id {
-		for k, v := range pointValues {
-			g, ok := pointGroups[k]
-			if !ok {
-				continue
-			}
-
-			// Write points into struct field
-			err := g.SetValue(v)
-			if err != nil {
-				retErr = errors.Join(retErr, fmt.Errorf("decode error for type %v: %w", k, err))
-			}
-		}
-	} else if len(childValues) > 0 {
-		// try children
-		for _, children := range childValues {
-			// v is an array, iterate through child array
-			for i := 0; i < children.Len(); i++ {
-				v := children.Index(i)
-				err := MergePoints(id, points, &v)
-				if err != nil {
-					retErr = errors.Join(retErr, fmt.Errorf("Error merging child points: %w", err))
-				}
-			}
-		}
-	}
-
-	return retErr
+	return Decode(NodeEdgeChildren{NodeEdge: ne}, outV)
 }
 
 // MergeEdgePoints takes edge points and updates a type that
 // matching edgepoint tags. See [Decode] for an example type.
-func MergeEdgePoints(id, parent string, points []Point, output interface{}) error {
-
-	var retErr error
-	vOut := reflect.Indirect(reflect.ValueOf(output))
-	tOut := vOut.Type()
-
-	if tOut == reflectValueT {
-		// `output` was a reflect.Value or *reflect.Value
-		vOut = vOut.Interface().(reflect.Value)
-		tOut = vOut.Type()
+func MergeEdgePoints(id, parent string, points []Point, outputStruct interface{}) error {
+	outV := FindNodeInStruct(outputStruct, id, parent)
+	if !outV.IsValid() {
+		return fmt.Errorf(
+			"no matching struct with a `node:\"id\"` field matching %v", id,
+		)
 	}
 
-	if k := tOut.Kind(); k != reflect.Struct {
-		return fmt.Errorf("Error decoding to %v; must be a struct", k)
+	ne := NodeEdge{
+		ID:         id,
+		Parent:     parent,
+		EdgePoints: points,
 	}
-
-	edgeGroups := make(map[string]GroupedPoints)
-
-	for _, p := range points {
-		g, ok := edgeGroups[p.Type]
-		if !ok {
-			g = GroupedPoints{}
-		}
-		if p.Key != "" {
-			g.Keyed = true
-		}
-		index, _ := strconv.Atoi(p.Key)
-		if index > g.IndexMax {
-			g.IndexMax = index
-		}
-		g.Points = append(g.Points, p)
-		edgeGroups[p.Type] = g
-	}
-
-	edgeValues := make(map[string]reflect.Value)
-	childValues := make(map[string]reflect.Value)
-
-	structID := ""
-	structParent := ""
-
-	for i := 0; i < tOut.NumField(); i++ {
-		sf := tOut.Field(i)
-		if et := sf.Tag.Get("edgepoint"); et != "" {
-			edgeValues[et] = vOut.Field(i)
-		} else if nt := sf.Tag.Get("node"); nt != "" {
-			if nt == "id" {
-				structID = vOut.Field(i).String()
-			} else if nt == "parent" {
-				structParent = vOut.Field(i).String()
-			}
-		} else if ct := sf.Tag.Get("child"); ct != "" {
-			childValues[ct] = vOut.Field(i)
-		}
-	}
-
-	if structID == id && structParent == parent {
-		for k, v := range edgeValues {
-			g, ok := edgeGroups[k]
-			// TODO: may be an optimization to check ok and not call SetValue if value
-			// in map does not exist, rather than processing the zero value
-			if !ok {
-				continue
-			}
-
-			// Write points into struct field
-			err := g.SetValue(v)
-			if err != nil {
-				retErr = errors.Join(retErr, fmt.Errorf("decode error for type %v: %w", k, err))
-			}
-		}
-	} else if len(childValues) > 0 {
-		// try children
-		for _, children := range childValues {
-			// v is an array, iterate through child array
-			for i := 0; i < children.Len(); i++ {
-				v := children.Index(i)
-				err := MergeEdgePoints(id, parent, points, &v)
-				if err != nil {
-					retErr = errors.Join(retErr, fmt.Errorf("merge error for child edge points: %w", err))
-				}
-			}
-		}
-	}
-
-	return retErr
+	return Decode(NodeEdgeChildren{NodeEdge: ne}, outV)
 }

--- a/go.mod
+++ b/go.mod
@@ -94,4 +94,4 @@ require (
 	modernc.org/token v1.0.0 // indirect
 )
 
-go 1.21
+go 1.20

--- a/go.mod
+++ b/go.mod
@@ -94,4 +94,4 @@ require (
 	modernc.org/token v1.0.0 // indirect
 )
 
-go 1.18
+go 1.21


### PR DESCRIPTION
A few things I'd like to note regarding this implementation:

- MergePoints / MergeEdgePoints now calls Decode under the hood (which simplifies things greatly and improves readability of `merge.go`)
- Decode is a bit more complicated now, but I'll explain a few of the more odd things below
- Primitive `setVal` function now sets deleted point (i.e. with `p.Tombstone%2==1`) to the zero value. This is true for array and slice values, although there is a small exception to slices described below
- Decode no longer overwrites fields with `node:"id"` or `node:"parent"` tags if the `input.NodeEdge.ID` or `input.NodeEdge.Parent` value is the empty string
- When decoding to a slice, as mentioned above, we now change the behavior of deleted points. Slices are never allocated / copied unless they are being expanded. Instead, deleted points are written to the slice as the zero value. However, for a given `Decode` call, if points are deleted from the *end* of the slice, `Decode` will re-slice it to remove those values from the slice. Thus, there is an important consideration for clients: if they wish to rely on slices being truncated when points are deleted, points must be batched in order such that `Decode` sees the trailing deleted points first. Put another way, `Decode` does not care about points deleted from prior calls to `Decode`, so "holes" of zero values may still appear at the end of a slice under certain circumstances. Consider points with integer values [0, 1, 2, 3, 4]. If tombstone is set on point with `Key` 3 followed by a point tombstone set on point with `Key` 4, the resulting slice will be [0, 1, 2] if these points are batched together, but if they are sent separately (thus resulting in multiple `Decode` calls), the resulting slice will be [0, 1, 2, 0].
- When decoding to a map, we still delete values from the map when point is deleted
- This is not a change, but to be clear, fields with `child:` tags are always initialized to a new slice if they are found in `input.Children`.