### PR TITLE
Allow encode/decoding of pointers to structs and primitives; fix bugs

### DIFF
--- a/data/decode.go
+++ b/data/decode.go
@@ -447,9 +447,11 @@ func setVal(p Point, v reflect.Value) error {
 		v.Set(reflect.Zero(v.Type()))
 		return nil
 	}
-	if v.Kind() == reflect.Pointer && v.IsNil() {
-		// Initialize pointer
-		v.Set(reflect.New(v.Type().Elem()))
+	if v.Kind() == reflect.Pointer {
+		if v.IsNil() {
+			// Initialize pointer
+			v.Set(reflect.New(v.Type().Elem()))
+		}
 		v = v.Elem()
 	}
 	switch k := v.Kind(); k {

--- a/data/decode.go
+++ b/data/decode.go
@@ -44,7 +44,46 @@ type GroupedPoints struct {
 // SetValue populates v with the Points in the group
 func (g GroupedPoints) SetValue(v reflect.Value) error {
 	t := v.Type()
-	switch k := t.Kind(); k {
+	k := t.Kind()
+	// Special case to handle pointers to structs
+	if k == reflect.Pointer && t.Elem().Kind() == reflect.Struct {
+		// Populate validFields with all fields in struct
+		validFields := make(map[string]bool)
+		i, numField := 0, t.Elem().NumField()
+		for ; i < numField; i++ {
+			sf := t.Elem().Field(i)
+			key := sf.Tag.Get("point")
+			if key == "" {
+				key = sf.Tag.Get("edgepoint")
+			}
+			if key == "" {
+				key = ToCamelCase(sf.Name)
+			}
+			validFields[key] = true
+		}
+		// Remove validFields as tombstone points are found
+		for _, p := range g.Points {
+			if p.Tombstone%2 == 1 {
+				delete(validFields, p.Key)
+			} else {
+				validFields[p.Key] = true
+			}
+		}
+		// If all points have tombstones, we just set the pointer to nil
+		if len(validFields) == 0 {
+			v.Set(reflect.Zero(t))
+			return nil
+		}
+		// If a valid point exists in the group, then initialize the pointer
+		// if needed
+		if v.IsNil() {
+			v.Set(reflect.New(t.Elem()))
+		}
+		v = v.Elem()
+		t = v.Type()
+		k = t.Kind()
+	}
+	switch k {
 	case reflect.Array, reflect.Slice:
 		// Ensure all keys are array indexes
 		if g.KeyNotIndex != "" {
@@ -104,17 +143,19 @@ func (g GroupedPoints) SetValue(v reflect.Value) error {
 		// were deleted in this decode. Note: this does not guarantee that
 		// slices are always trimmed completely (for example, values can be
 		// deleted across multiple calls of Decode)
-		slices.Sort(deletedIndexes)
-		lastIndex := v.Len() - 1
-		for i := len(deletedIndexes) - 1; i >= 0; i-- {
-			if deletedIndexes[i] < lastIndex {
-				break
-			} else if deletedIndexes[i] == lastIndex {
-				lastIndex--
+		if k == reflect.Slice {
+			slices.Sort(deletedIndexes)
+			lastIndex := v.Len() - 1
+			for i := len(deletedIndexes) - 1; i >= 0; i-- {
+				if deletedIndexes[i] < lastIndex {
+					break
+				} else if deletedIndexes[i] == lastIndex {
+					lastIndex--
+				}
+				// else only decrement i
 			}
-			// else only decrement i
+			v.Set(v.Slice(0, lastIndex+1))
 		}
-		v.Set(v.Slice(0, lastIndex+1))
 	case reflect.Map:
 		// Ensure map is keyed by string
 		if keyK := t.Key().Kind(); keyK != reflect.String {
@@ -182,9 +223,11 @@ func (g GroupedPoints) SetValue(v reflect.Value) error {
 			if key == "" {
 				return fmt.Errorf("point missing Key")
 			}
-			err := setVal(values[key], v.Field(i))
-			if err != nil {
-				return err
+			if val, ok := values[key]; ok {
+				err := setVal(val, v.Field(i))
+				if err != nil {
+					return err
+				}
 			}
 		}
 	default:
@@ -241,7 +284,7 @@ func (g GroupedPoints) SetValue(v reflect.Value) error {
 // slice will be [0, 1, 2] if these points are batched together, but
 // if they are sent separately (thus resulting in multiple Decode calls),
 // the resulting slice will be [0, 1, 2, 0].
-func Decode(input NodeEdgeChildren, outputStruct interface{}) error {
+func Decode(input NodeEdgeChildren, outputStruct any) error {
 	outV, outT, outK := reflectValue(outputStruct)
 	if outK != reflect.Struct {
 		return fmt.Errorf("error decoding to %v; must be a struct", outK)
@@ -404,6 +447,11 @@ func setVal(p Point, v reflect.Value) error {
 		v.Set(reflect.Zero(v.Type()))
 		return nil
 	}
+	if v.Kind() == reflect.Pointer && v.IsNil() {
+		// Initialize pointer
+		v.Set(reflect.New(v.Type().Elem()))
+		v = v.Elem()
+	}
 	switch k := v.Kind(); k {
 	case reflect.Bool:
 		v.SetBool(FloatToBool(p.Value))
@@ -439,7 +487,7 @@ func setVal(p Point, v reflect.Value) error {
 
 // reflectValue returns a reflect.Value from an interface
 // This function dereferences `output` if it's a pointer or a reflect.Value
-func reflectValue(output interface{}) (
+func reflectValue(output any) (
 	outV reflect.Value, outT reflect.Type, outK reflect.Kind,
 ) {
 	outV = reflect.Indirect(reflect.ValueOf(output))

--- a/data/encode.go
+++ b/data/encode.go
@@ -17,7 +17,16 @@ const maxStructureSize = 1000
 
 func pointFromPrimitive(pointType string, v reflect.Value) (Point, error) {
 	p := Point{Type: pointType}
-	k := v.Type().Kind()
+	k := v.Kind()
+
+	if k == reflect.Pointer {
+		if v.IsNil() {
+			p.Tombstone = 1
+			return p, nil
+		}
+		v = v.Elem()
+		k = v.Kind()
+	}
 	switch k {
 	case reflect.Bool:
 		p.Value = BoolToFloat(v.Bool())
@@ -71,7 +80,7 @@ func appendPointsFromValue(
 		for i := 0; i < v.Len(); i++ {
 			p, err := pointFromPrimitive(pointType, v.Index(i))
 			if err != nil {
-				return points, fmt.Errorf("unsupported type: %v of %w", k, err)
+				return points, fmt.Errorf("%v of %w", k, err)
 			}
 			p.Key = strconv.Itoa(i)
 			points = append(points, p)
@@ -123,6 +132,56 @@ func appendPointsFromValue(
 			p.Key = key
 			points = append(points, p)
 		}
+	case reflect.Pointer:
+		// We support pointers to primitives and structs
+		// If the pointer is nil, all generated points will have a tombstone set
+		if !v.IsNil() {
+			return appendPointsFromValue(points, pointType, v.Elem())
+		}
+		switch k := t.Elem().Kind(); k {
+		case reflect.Struct:
+			// Generate a tombstone point for all struct fields
+			numField := t.Elem().NumField()
+			if numField > maxStructureSize {
+				return points, fmt.Errorf(
+					"%v size of %v exceeds maximum of %v",
+					k, numField, maxStructureSize,
+				)
+			}
+			for i := 0; i < numField; i++ {
+				sf := t.Elem().Field(i)
+				key := sf.Tag.Get("point")
+				if key == "" {
+					key = sf.Tag.Get("edgepoint")
+				}
+				if key == "" {
+					key = ToCamelCase(sf.Name)
+				}
+				p := Point{
+					Type:      pointType,
+					Key:       key,
+					Tombstone: 1,
+				}
+				points = append(points, p)
+			}
+		case reflect.Bool,
+			reflect.Int,
+			reflect.Int8,
+			reflect.Int16,
+			reflect.Int32,
+			reflect.Int64,
+			reflect.Uint,
+			reflect.Uint8,
+			reflect.Uint16,
+			reflect.Uint32,
+			reflect.Uint64,
+			reflect.Float32,
+			reflect.Float64,
+			reflect.String:
+			points = append(points, Point{Type: pointType, Tombstone: 1})
+		default:
+			return points, fmt.Errorf("unsupported pointer type: %v", k)
+		}
 	default:
 		p, err := pointFromPrimitive(pointType, v)
 		if err != nil {
@@ -167,27 +226,28 @@ func ToCamelCase(s string) string {
 //		Role        string  `edgepoint:"role"`
 //		Tombstone   bool    `edgepoint:"tombstone"`
 //	   }
-func Encode(in interface{}) (NodeEdge, error) {
-	vIn := reflect.ValueOf(in)
-	tIn := reflect.TypeOf(in)
-
-	nodeType := ToCamelCase(tIn.Name())
-
+func Encode(in any) (NodeEdge, error) {
+	inV, inT, inK := reflectValue(in)
+	nodeType := ToCamelCase(inT.Name())
 	ret := NodeEdge{Type: nodeType}
-	var err error
 
-	for i := 0; i < tIn.NumField(); i++ {
-		sf := tIn.Field(i)
+	if inK != reflect.Struct {
+		return ret, fmt.Errorf("error decoding to %v; must be a struct", inK)
+	}
+
+	var err error
+	for i := 0; i < inT.NumField(); i++ {
+		sf := inT.Field(i)
 		if pt := sf.Tag.Get("point"); pt != "" {
 			ret.Points, err = appendPointsFromValue(
-				ret.Points, pt, vIn.Field(i),
+				ret.Points, pt, inV.Field(i),
 			)
 			if err != nil {
 				return ret, err
 			}
 		} else if et := sf.Tag.Get("edgepoint"); et != "" {
 			ret.EdgePoints, err = appendPointsFromValue(
-				ret.EdgePoints, et, vIn.Field(i),
+				ret.EdgePoints, et, inV.Field(i),
 			)
 			if err != nil {
 				return ret, err
@@ -196,9 +256,9 @@ func Encode(in interface{}) (NodeEdge, error) {
 			sf.Type.Kind() == reflect.String {
 
 			if nt == "id" {
-				ret.ID = vIn.Field(i).String()
+				ret.ID = inV.Field(i).String()
 			} else if nt == "parent" {
-				ret.Parent = vIn.Field(i).String()
+				ret.Parent = inV.Field(i).String()
 			}
 		}
 	}

--- a/data/encode_decode_test.go
+++ b/data/encode_decode_test.go
@@ -111,15 +111,16 @@ func TestEncodeCase(t *testing.T) {
 }
 
 type testTypeComplex struct {
-	ID          string            `node:"id"`
-	Parent      string            `node:"parent"`
-	Description string            `point:"description"`
-	IPAddresses []string          `point:"ipAddress"`
-	Location    map[string]string `point:"location"`
-	Sensors     map[string]int    `point:"sensor"`
-	Nested      TestType          `point:"nested"`
-	TestValues  []int32           `edgepoint:"testValue"`
-	Tombstone   bool              `edgepoint:"tombstone"`
+	ID            string            `node:"id"`
+	Parent        string            `node:"parent"`
+	Description   string            `point:"description"`
+	IPAddresses   []string          `point:"ipAddress"`
+	Location      map[string]string `point:"location"`
+	Sensors       map[string]int    `point:"sensor"`
+	Nested        TestType          `point:"nested"`
+	ScheduledDays [7]bool           `point:"scheduledDays"`
+	TestValues    []int32           `edgepoint:"testValue"`
+	Tombstone     bool              `edgepoint:"tombstone"`
 }
 
 var testTypeComplexData = testTypeComplex{"123", "456", "hi there",
@@ -133,6 +134,7 @@ var testTypeComplexData = testTypeComplex{"123", "456", "hi there",
 		"temp2": 40,
 	},
 	TestType{"789", "456", "nested test type"},
+	[7]bool{false, true, true, true, true, true, false},
 	[]int32{314, 1024},
 	true,
 }
@@ -150,6 +152,13 @@ var nodeEdgeTestComplex = NodeEdge{
 		{Type: "nested", Key: "description", Text: "nested test type"},
 		{Type: "nested", Key: "id", Text: "789"},
 		{Type: "nested", Key: "parent", Text: "456"},
+		{Type: "scheduledDays", Key: "0", Value: 0},
+		{Type: "scheduledDays", Key: "1", Value: 1},
+		{Type: "scheduledDays", Key: "2", Value: 1},
+		{Type: "scheduledDays", Key: "3", Value: 1},
+		{Type: "scheduledDays", Key: "4", Value: 1},
+		{Type: "scheduledDays", Key: "5", Value: 1},
+		{Type: "scheduledDays", Key: "6", Value: 0},
 		{Type: "sensor", Key: "temp1", Value: 23},
 		{Type: "sensor", Key: "temp2", Value: 40},
 	},
@@ -157,6 +166,32 @@ var nodeEdgeTestComplex = NodeEdge{
 		{Type: "testValue", Key: "0", Value: 314},
 		{Type: "testValue", Key: "1", Value: 1024},
 		{Type: "tombstone", Value: 1},
+	},
+}
+
+type testTypePointers struct {
+	ID          string    `node:"id"`
+	Description *string   `point:"description"`
+	IPAddresses []string  `point:"ipAddress"`
+	NullStruct  *TestType `point:"nullStruct"`
+	NullValue   *float64  `point:"nullValue"`
+	NullEdge    *int      `edgepoint:"nullEdge"`
+	Value       *float32  `edgepoint:"value"`
+}
+
+var testTypePointersNodeEdge = NodeEdge{
+	ID:   "nodeID",
+	Type: "testTypePointers",
+	Points: []Point{
+		{Type: "description", Text: "testing 1, 2, 3"},
+		{Type: "nullStruct", Key: "description", Tombstone: 1},
+		{Type: "nullStruct", Key: "id", Tombstone: 1},
+		{Type: "nullStruct", Key: "parent", Tombstone: 1},
+		{Type: "nullValue", Tombstone: 1},
+	},
+	EdgePoints: []Point{
+		{Type: "nullEdge", Tombstone: 1},
+		{Type: "value", Value: 42},
 	},
 }
 
@@ -307,13 +342,18 @@ func TestDecodeTombstonePoint(t *testing.T) {
 			{Type: "location", Key: "goodbye", Text: "cruel world"},
 			{Type: "location", Key: "hello", Text: "world"},
 			{Type: "location", Key: "del", Text: "deleted entry", Tombstone: 1},
+			{Type: "nested", Key: "fake", Text: "not a real field", Tombstone: 1},
 		},
 	}
 
 	var out testTypeComplex
+	out.Nested.Description = "decode should not change this value"
 	err := Decode(NodeEdgeChildren{ne, nil}, &out)
 
 	exp := testTypeComplex{
+		Nested: TestType{
+			Description: "decode should not change this value",
+		},
 		IPAddresses: []string{"192.168.1.1", "127.0.0.1"},
 		Location: map[string]string{
 			"hello":   "world",
@@ -348,6 +388,60 @@ func TestDecodeAllTombstonePointArray(t *testing.T) {
 
 	if len(out.IPAddresses) > 0 {
 		t.Error("Expected 0 IP address, got: ", len(out.IPAddresses))
+	}
+}
+
+func TestEncodePointers(t *testing.T) {
+	str := "testing 1, 2, 3"
+	value := float32(42)
+	ne, err := Encode(testTypePointers{
+		ID:          "nodeID",
+		Description: &str,
+		Value:       &value,
+	})
+
+	if err != nil {
+		t.Fatal("encode failed:", err)
+	}
+	sortPoints(ne.Points, ne.EdgePoints)
+
+	if !reflect.DeepEqual(ne, testTypePointersNodeEdge) {
+		t.Errorf("Decode failed, exp: %v, got %v", testTypePointersNodeEdge, ne)
+	}
+}
+
+func TestDecodePointers(t *testing.T) {
+	desc := "Test description"
+	nullValue := 85.7
+	out := testTypePointers{
+		ID:          "123",
+		Description: &desc,
+		IPAddresses: []string{"127.0.0.1"},
+		NullStruct: &TestType{
+			Description: "hello there",
+		},
+		NullValue: &nullValue,
+	}
+	err := Decode(NodeEdgeChildren{testTypePointersNodeEdge, nil}, &out)
+
+	desc = "testing 1, 2, 3"
+	value := float32(42)
+	exp := testTypePointers{
+		ID:          "nodeID",
+		Description: &desc,
+		IPAddresses: []string{"127.0.0.1"}, // unchanged
+		NullStruct:  nil,                   // all fields are tombstone points
+		NullValue:   nil,                   // tombstone point
+		NullEdge:    nil,                   // tombstone point
+		Value:       &value,
+	}
+
+	if err != nil {
+		t.Fatal("Error decoding: ", err)
+	}
+
+	if !reflect.DeepEqual(out, exp) {
+		t.Errorf("Decode failed, exp: %v, got %v", exp, out)
 	}
 }
 
@@ -423,6 +517,7 @@ func TestDiffPointsComplex(t *testing.T) {
 			"temp2": 40,
 		},
 		TestType{"789", "456", "nested test type"},
+		[7]bool{false, true, true, true, true, true, false},
 		[]int32{314, 1024},
 		true,
 	}
@@ -438,6 +533,7 @@ func TestDiffPointsComplex(t *testing.T) {
 			"temp2": 40, // unchanged
 		},
 		TestType{"789", "456", "nested test type desc changed"},
+		[7]bool{false, true, true, false, true, true, false},
 		// ignore edgepoints
 		[]int32{314, 1000, 2048, 4096},
 		false,
@@ -446,9 +542,10 @@ func TestDiffPointsComplex(t *testing.T) {
 	if err != nil {
 		t.Fatal("diff error:", err)
 	}
+	sortPoints(p)
 	// log.Println(p)
-	if len(p) != 6 {
-		t.Fatalf("expected 6 points; got %v", len(p))
+	if len(p) != 7 {
+		t.Fatalf("expected 7 points; got %v", len(p))
 	}
 	if p[0].Value != 0 ||
 		p[0].Text != "192.168.1.100" ||
@@ -465,31 +562,38 @@ func TestDiffPointsComplex(t *testing.T) {
 		t.Errorf("generated point invalid; got %v", p[1])
 	}
 	if p[2].Value != 0 ||
-		p[2].Text != "world!!!" ||
-		p[2].Key != "hello" ||
+		p[2].Text != "bar" ||
+		p[2].Key != "foo" ||
 		p[2].Type != "location" ||
 		p[2].Tombstone != 0 {
-		t.Errorf("generated point invalid; got %v", p[2])
-	}
-	if p[3].Value != 0 ||
-		p[3].Text != "bar" ||
-		p[3].Key != "foo" ||
-		p[3].Type != "location" ||
-		p[3].Tombstone != 0 {
 		t.Errorf("generated point invalid; got %v", p[3])
 	}
-	if p[4].Value != 0 ||
-		p[4].Text != "" ||
-		p[4].Key != "goodbye" ||
-		p[4].Type != "location" ||
-		p[4].Tombstone != 1 {
+	if p[3].Value != 0 ||
+		p[3].Text != "" ||
+		p[3].Key != "goodbye" ||
+		p[3].Type != "location" ||
+		p[3].Tombstone != 1 {
 		t.Errorf("generated point invalid; got %v", p[4])
+	}
+	if p[4].Value != 0 ||
+		p[4].Text != "world!!!" ||
+		p[4].Key != "hello" ||
+		p[4].Type != "location" ||
+		p[4].Tombstone != 0 {
+		t.Errorf("generated point invalid; got %v", p[2])
 	}
 	if p[5].Value != 0 ||
 		p[5].Text != "nested test type desc changed" ||
 		p[5].Key != "description" ||
 		p[5].Type != "nested" ||
 		p[5].Tombstone != 0 {
+		t.Errorf("generated point invalid; got %v", p[5])
+	}
+	if p[6].Value != 0 ||
+		p[6].Text != "" ||
+		p[6].Key != "3" ||
+		p[6].Type != "scheduledDays" ||
+		p[6].Tombstone != 0 {
 		t.Errorf("generated point invalid; got %v", p[5])
 	}
 }


### PR DESCRIPTION
Encode notes:
- Set tombstone flag on a point if pointer to primitive is `nil`
- For `nil` pointer to a struct, generate tombstone points for each field in the struct.

Decode notes:
- If entire struct is matched with tombstone points, set pointer to `nil`
- Bugfix: Do not try to re-slice / truncate an array
- Bugfix: When decoding to struct, do not write value for missing point