### PR TITLE
Added DiffPoints function

### DIFF
--- a/data/time_window_avg_test.go
+++ b/data/time_window_avg_test.go
@@ -7,6 +7,10 @@ import (
 )
 
 func TestNewPoint(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	var avgPoint Point
 
 	point := Point{


### PR DESCRIPTION
This function compares two structs of the same type and generates a set of Points representing their differences.

This can be useful when structs are already populated with values and you just need to emit points representing their differences. It can aid in synchronizing with external data sources. As an example use case, I am using this function with the NetworkManager code, as these structs are populated by querying NetworkManager's D-Bus API. I then compare to current configuration to compute which points to emit to update the SIOT tree.