### PR TITLE
Signal generator now supports more signal types

### DIFF
--- a/client/signal-generator.go
+++ b/client/signal-generator.go
@@ -18,6 +18,7 @@ type SignalGenerator struct {
 	Parent      string `node:"parent"`
 	Description string `point:"description"`
 	Disable     bool   `point:"disable"`
+	SyncParent  bool   `point:"syncParent"`
 	Units       string `point:"units"`
 	// SignalType must be one of: "sine", "square", "triangle", or "random walk"
 	SignalType string  `point:"signalType"`
@@ -161,9 +162,14 @@ func (sgc *SignalGeneratorClient) Run() error {
 			configValid = false
 		}
 
-		natsSubject := SubjectNodePoints(config.ID)
+		// Determine NATS subject for points based on config settings
+		var natsSubject string
 		if config.HighRate {
 			natsSubject = fmt.Sprintf("phrup.%v.%v", config.Parent, config.ID)
+		} else if config.SyncParent {
+			natsSubject = SubjectNodePoints(config.Parent)
+		} else {
+			natsSubject = SubjectNodePoints(config.ID)
 		}
 
 		lastBatchTime := time.Now()


### PR DESCRIPTION
New signal types include square and triangle waves along with random walk

Options for signal generator have changed:
- added signal type option (sine, square, triangle, or random walk)
- amplitude was replaced by min/max value
- offset has been replaced by initial value (for sine, square, and triangle, this is measured in radians)
- added "round to" option. Can round to nearest tenth by setting to 0.1, for example.
- add min/max increment value for "random walk". If you specify -0.1 and 0.2 respectively, the value will tend to increase more than decrease, for example.

Also improved how batch period timer works.