### PR TITLE
network-manager: Many sync improvements

### DIFF
--- a/client/network-manager-conn.go
+++ b/client/network-manager-conn.go
@@ -276,6 +276,7 @@ func (c IPv4Config) Equal(c2 IPv4Config) bool {
 	return reflect.DeepEqual(c, c2)
 }
 
+// Method returns the IP configuration method (i.e. "auto" or "manual")
 func (c IPv4Config) Method() string {
 	if c.StaticIP &&
 		c.Address.Valid() &&
@@ -391,6 +392,7 @@ func (c IPv6Config) Equal(c2 IPv6Config) bool {
 	return reflect.DeepEqual(c, c2)
 }
 
+// Method returns the IP configuration method (i.e. "auto" or "manual")
 func (c IPv6Config) Method() string {
 	if c.StaticIP &&
 		c.Address.Valid() &&

--- a/client/network-manager-device.go
+++ b/client/network-manager-device.go
@@ -11,11 +11,12 @@ import (
 
 // NetworkManagerDevice is a device managed by NetworkManager
 type NetworkManagerDevice struct {
-	ID        string `node:"id"`
-	Parent    string `node:"parent"`
-	Path      string `point:"path"`
-	Interface string `point:"interface"`
-	State     string `point:"state"`
+	ID         string `node:"id"`
+	Parent     string `node:"parent"`
+	Path       string `point:"path"`
+	Interface  string `point:"interface"`
+	State      string `point:"state"`
+	DeviceType string `point:"deviceType"`
 	// ActiveConnectionID
 	IPv4Addresses   []IPv4Address `point:"ipv4Addresses"`
 	IPv4Netmasks    []IPv4Netmask `point:"ipv4Netmasks"`
@@ -27,7 +28,6 @@ type NetworkManagerDevice struct {
 	IPv6Nameservers []IPv6Address `point:"ipv6Nameservers"`
 	HardwareAddress string        `point:"hardwareAddress"`
 	Managed         bool
-	DeviceType      string `point:"deviceType"`
 	// Wi-Fi specific properties
 	ActiveAccessPoint *AccessPoint `point:"activeAccessPoint"`
 	AccessPoints      []string     `point:"accessPoints"` // JSON-encoded strings

--- a/client/subject.go
+++ b/client/subject.go
@@ -59,13 +59,12 @@ func (sd Destination) Subject(originID string, parentID string) string {
 			destID = sd.NodeID
 		}
 		return fmt.Sprintf("phrup.%v.%v", destID, originID)
-	} else {
-		destID := originID
-		if sd.NodeID != "" {
-			destID = sd.NodeID
-		} else if sd.Parent {
-			destID = parentID
-		}
-		return SubjectNodePoints(destID)
 	}
+	destID := originID
+	if sd.NodeID != "" {
+		destID = sd.NodeID
+	} else if sd.Parent {
+		destID = parentID
+	}
+	return SubjectNodePoints(destID)
 }


### PR DESCRIPTION
- NetworkManagerConn now has error point type, containing an error message of the last SyncConnections() call
- Errors logged by SyncConnections() are now muted unless connection node point is updated
- NetworkManagerConns are now considered Equal if they produce the same D-Bus settings

# Checklist

Please verify this PR includes the following if relevant:

- [x] `siot_test` passes
- [ ] `CHANGELOG.md` entry created/updated
- [ ] [docs/](https://github.com/simpleiot/simpleiot/tree/master/docs)
      created/updated

Thanks!
