### PR TITLE
Replace deprecated `io/ioutil` functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For more details or to discuss releases, please visit the
 ## [Unreleased]
 
 - simpleiot-js: Fixed bugs and improved README
+- Replace deprecated `io/ioutil` functions (#680)
 
 ## [[0.14.4] - 2023-12-19](https://github.com/simpleiot/simpleiot/releases/tag/v0.14.4)
 

--- a/api/client.go
+++ b/api/client.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"time"
@@ -97,7 +97,7 @@ func NewSendPoints(portalURL, deviceID, authToken string, timeout time.Duration,
 
 		if resp.StatusCode != http.StatusOK {
 			errstring := "Server error: " + resp.Status + " " + pointURL
-			body, _ := ioutil.ReadAll(resp.Body)
+			body, _ := io.ReadAll(resp.Body)
 			errstring += " " + string(body)
 			return errors.New(errstring)
 		}

--- a/api/http-logger.go
+++ b/api/http-logger.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -34,10 +33,10 @@ func (l *HTTPLogger) Handler(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
 		var rdr io.ReadCloser
-		buf, err := ioutil.ReadAll(r.Body)
+		buf, err := io.ReadAll(r.Body)
 		if err == nil {
-			rdr = ioutil.NopCloser(bytes.NewBuffer(buf))
-			rdr2 := ioutil.NopCloser(bytes.NewBuffer(buf))
+			rdr = io.NopCloser(bytes.NewBuffer(buf))
+			rdr2 := io.NopCloser(bytes.NewBuffer(buf))
 			r.Body = rdr2
 		}
 

--- a/api/nodes.go
+++ b/api/nodes.go
@@ -2,7 +2,7 @@ package api
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 
@@ -108,7 +108,7 @@ func (h *Nodes) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	case "":
 		switch req.Method {
 		case http.MethodGet:
-			body, err := ioutil.ReadAll(req.Body)
+			body, err := io.ReadAll(req.Body)
 			if err != nil {
 				http.Error(res, err.Error(), http.StatusNotFound)
 				return

--- a/client/file-transfer.go
+++ b/client/file-transfer.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
+	"os"
 	"path"
 	"time"
 
@@ -65,7 +65,7 @@ func ListenForFile(nc *nats.Conn, dir, deviceID string, callback func(path strin
 			dl = fileDownload{}
 		case pb.FileChunk_DONE:
 			filePath := path.Join(dir, dl.name)
-			err := ioutil.WriteFile(filePath, dl.data, 0644)
+			err := os.WriteFile(filePath, dl.data, 0644)
 			if err != nil {
 				log.Println("Error writing dl file: ", err)
 				err := nc.Publish(m.Reply, []byte("error writing"))

--- a/network/ethernet.go
+++ b/network/ethernet.go
@@ -2,7 +2,7 @@ package network
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 )
 
@@ -36,7 +36,7 @@ func (e *Ethernet) Connect() error {
 }
 
 func (e *Ethernet) detected() bool {
-	cnt, err := ioutil.ReadFile("/sys/class/net/" + e.iface + "/carrier")
+	cnt, err := os.ReadFile("/sys/class/net/" + e.iface + "/carrier")
 	if err != nil {
 		return false
 	}
@@ -45,7 +45,7 @@ func (e *Ethernet) detected() bool {
 		return false
 	}
 
-	cnt, err = ioutil.ReadFile("/sys/class/net/" + e.iface + "/operstate")
+	cnt, err = os.ReadFile("/sys/class/net/" + e.iface + "/operstate")
 	if err != nil {
 		return false
 	}

--- a/node/onewire-io.go
+++ b/node/onewire-io.go
@@ -3,8 +3,8 @@ package node
 import (
 	"fmt"
 	goio "io"
-	"io/ioutil"
 	"log"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -101,7 +101,7 @@ func (io *oneWireIO) read() error {
 		return nil
 	}
 
-	d, err := ioutil.ReadFile(io.path)
+	d, err := os.ReadFile(io.path)
 	if err != nil {
 		return err
 	}

--- a/system/os_version_linux.go
+++ b/system/os_version_linux.go
@@ -2,7 +2,7 @@ package system
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/blang/semver/v4"
 )
@@ -12,7 +12,7 @@ const releaseFilePath = "/etc/os-release"
 // ReadOSVersion reads `releaseFilePath` and parses VERSION_ID into a `Version` struct
 func ReadOSVersion(field string) (imgRelease semver.Version, err error) {
 	// Read `releaseFilePath` into []byte
-	data, err := ioutil.ReadFile(releaseFilePath)
+	data, err := os.ReadFile(releaseFilePath)
 	if err != nil {
 		return
 	}

--- a/system/timezone.go
+++ b/system/timezone.go
@@ -15,12 +15,7 @@ import (
 //	"posix/America"
 func ReadTimezones(zoneInfoDir string) (listZones []string, err error) {
 
-	file, err := os.Open(path.Join(zoneInfoPath, zoneInfoDir))
-	if err != nil {
-		return nil, err
-	}
-
-	fileInfo, err := file.Readdir(-1)
+	fileInfo, err := os.ReadDir(path.Join(zoneInfoPath, zoneInfoDir))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The `io/ioutil` package has been deprecated as of Go 1.16 [^1]. This commit replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

[^1]: https://golang.org/doc/go1.16#ioutil

# Checklist

Please verify this PR includes the following if relevant:

- [x] `siot_test` passes
- [x] `CHANGELOG.md` entry created/updated
- [ ] [docs/](https://github.com/simpleiot/simpleiot/tree/master/docs)
      created/updated

Thanks!
