### PR TITLE
client.ExportNodes now works with `id` of "root"

### DIFF
--- a/cmd/siot/main.go
+++ b/cmd/siot/main.go
@@ -462,14 +462,6 @@ func runImport(args []string) {
 		log.Fatal("Error: timeout reading YAML from STDIN")
 	}
 
-	if *flagParentID == "" {
-		root, err := client.GetRootNode(nc)
-		if err != nil {
-			log.Fatal("Error getting root node: ", err)
-		}
-		*flagParentID = root.ID
-	}
-
 	err = client.ImportNodes(nc, *flagParentID, yaml, "import", *flagPreserveIDs)
 	if err != nil {
 		log.Fatal("Error importing nodes: ", err)
@@ -528,14 +520,6 @@ func runExport(args []string) {
 	nc, err := client.EdgeConnect(opts)
 	if err != nil {
 		log.Fatal("Error connecting to NATS server: ", err)
-	}
-
-	if *flagNodeID == "" {
-		root, err := client.GetRootNode(nc)
-		if err != nil {
-			log.Fatal("Error getting root node: ", err)
-		}
-		*flagNodeID = root.ID
 	}
 
 	yaml, err := client.ExportNodes(nc, *flagNodeID)


### PR DESCRIPTION
# Checklist

Please verify this PR includes the following if relevant:

- [x] `siot_test` passes
- [ ] `CHANGELOG.md` entry created/updated
- [ ] [docs/](https://github.com/simpleiot/simpleiot/tree/master/docs)
      created/updated

Thanks!

Closes https://github.com/simpleiot/simpleiot/issues/690