### PR TITLE
server: Args now accepts a *FlagSet to allow flags to be extended

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ For more details or to discuss releases, please visit the
 
 ## [Unreleased]
 
+- server: Args now accepts a `*FlagSet` to allow flags to be extended
+
 ## [[0.14.10] - 2024-02-05](https://github.com/simpleiot/simpleiot/releases/tag/v0.14.10)
 
 - store: Improved performance when loading many nodes and edges

--- a/cmd/siot/main.go
+++ b/cmd/siot/main.go
@@ -87,7 +87,8 @@ func main() {
 }
 
 func runServer(args []string, version string, id string) error {
-	options, err := server.Args(args)
+	flags := flag.NewFlagSet("serve", flag.ExitOnError)
+	options, err := server.Args(args, flags)
 	if err != nil {
 		return err
 	}

--- a/server/args.go
+++ b/server/args.go
@@ -12,13 +12,15 @@ import (
 )
 
 // Args parses common SIOT command line options
-func Args(args []string) (Options, error) {
+func Args(args []string, flags *flag.FlagSet) (Options, error) {
 	defaultNatsServer := "nats://127.0.0.1:4222"
 
 	// =============================================
 	// Command line options
 	// =============================================
-	flags := flag.NewFlagSet("server", flag.ExitOnError)
+	if flags == nil {
+		flags = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	}
 
 	// configuration options
 	flagDebugHTTP := flags.Bool("debugHttp", false, "dump http requests")


### PR DESCRIPTION
# Checklist

Please verify this PR includes the following if relevant:

- [x] `siot_test` passes
- [x] `CHANGELOG.md` entry created/updated
- [x] [docs/](https://github.com/simpleiot/simpleiot/tree/master/docs)
      created/updated

Thanks!
