### PR TITLE
Fix instances of `log.Println` being called with extra space

### DIFF
--- a/api/auth.go
+++ b/api/auth.go
@@ -57,6 +57,6 @@ func (auth Auth) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	})
 
 	if err != nil {
-		log.Println("Error encoding: ", err)
+		log.Println("Error encoding:", err)
 	}
 }

--- a/api/client.go
+++ b/api/client.go
@@ -77,7 +77,7 @@ func NewSendPoints(portalURL, deviceID, authToken string, timeout time.Duration,
 		}
 
 		if debug {
-			log.Println("Sending points: ", string(tempJSON))
+			log.Println("Sending points:", string(tempJSON))
 		}
 
 		req, err := http.NewRequest("POST", pointURL, bytes.NewBuffer(tempJSON))

--- a/api/nodes.go
+++ b/api/nodes.go
@@ -77,7 +77,7 @@ func (h *Nodes) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 
 			nodes, err := client.GetNodesForUser(h.nc, userID)
 			if err != nil {
-				log.Println("Error getting nodes for user: ", err)
+				log.Println("Error getting nodes for user:", err)
 			}
 
 			if err != nil {
@@ -174,7 +174,7 @@ func (h *Nodes) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 				nodeMove.NewParent, userID)
 
 			if err != nil {
-				log.Println("Error moving node: ", err)
+				log.Println("Error moving node:", err)
 				http.Error(res, err.Error(), http.StatusNotFound)
 				return
 			}
@@ -196,7 +196,7 @@ func (h *Nodes) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 				err := client.MirrorNode(h.nc, id, nodeCopy.NewParent, userID)
 
 				if err != nil {
-					log.Println("Error mirroring node: ", err)
+					log.Println("Error mirroring node:", err)
 					http.Error(res, err.Error(), http.StatusNotFound)
 					return
 				}
@@ -204,7 +204,7 @@ func (h *Nodes) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 				err := client.DuplicateNode(h.nc, id, nodeCopy.NewParent, userID)
 
 				if err != nil {
-					log.Println("Error duplicating node: ", err)
+					log.Println("Error duplicating node:", err)
 					http.Error(res, err.Error(), http.StatusNotFound)
 					return
 				}

--- a/api/server.go
+++ b/api/server.go
@@ -58,7 +58,7 @@ func NewAppHandler(args ServerArgs) http.Handler {
 		uS := fmt.Sprintf("ws://localhost:%v", args.NatsWSPort)
 		u, err := url.Parse(uS)
 		if err != nil {
-			log.Println("Error with WS url: ", err)
+			log.Println("Error with WebSocket URL:", err)
 		} else {
 			wsProxy = websocketproxy.NewProxy(u)
 		}
@@ -99,8 +99,8 @@ func NewServer(args ServerArgs) *Server {
 
 // Start the api server
 func (s *Server) Start() error {
-	log.Println("Starting http server, debug: ", s.args.Debug)
-	log.Println("Starting portal on port: ", s.args.Port)
+	log.Println("Starting http server, debug:", s.args.Debug)
+	log.Println("Starting portal on port:", s.args.Port)
 	address := fmt.Sprintf(":%s", s.args.Port)
 
 	var err error

--- a/client/can.go
+++ b/client/can.go
@@ -187,7 +187,7 @@ func (cb *CanBusClient) Run() error {
 	for {
 		select {
 		case <-cb.stop:
-			log.Println("CanBusClient: stopping CAN bus client: ", cb.config.Description)
+			log.Println("CanBusClient: stopping CAN bus client:", cb.config.Description)
 			bringDownDev()
 			return nil
 
@@ -236,7 +236,7 @@ func (cb *CanBusClient) Run() error {
 		case pts := <-cb.newPoints:
 			err := data.MergePoints(pts.ID, pts.Points, &cb.config)
 			if err != nil {
-				log.Println("CanBusClient: error merging new points: ", err)
+				log.Println("CanBusClient: error merging new points:", err)
 			}
 
 			// Update CAN devices and databases with new information
@@ -262,7 +262,7 @@ func (cb *CanBusClient) Run() error {
 				}
 				err = SendPoints(cb.nc, cb.natsSub, points, false)
 				if err != nil {
-					log.Println("Error resetting CAN message received count: ", err)
+					log.Println("Error resetting CAN message received count:", err)
 				}
 
 				cb.config.MsgsRecvdDbReset = false
@@ -277,7 +277,7 @@ func (cb *CanBusClient) Run() error {
 				}
 				err = SendPoints(cb.nc, cb.natsSub, points, false)
 				if err != nil {
-					log.Println("Error resetting CAN message received count: ", err)
+					log.Println("Error resetting CAN message received count:", err)
 				}
 
 				cb.config.MsgsRecvdOtherReset = false
@@ -287,7 +287,7 @@ func (cb *CanBusClient) Run() error {
 		case pts := <-cb.newEdgePoints:
 			err := data.MergeEdgePoints(pts.ID, pts.Parent, pts.Points, &cb.config)
 			if err != nil {
-				log.Println("CanBusClient: error merging new points: ", err)
+				log.Println("CanBusClient: error merging new points:", err)
 			}
 
 			// TODO need to send edge points to CAN bus, not implemented yet

--- a/client/client-state.go
+++ b/client/client-state.go
@@ -79,7 +79,7 @@ func (cs *clientState[T]) run() (err error) {
 	case <-chClientStopped:
 		// everything is OK
 	case <-time.After(5 * time.Second):
-		log.Println("Timeout stopping client: ", cs.node.Type, cs.node.ID)
+		log.Println("Timeout stopping client:", cs.node.Type, cs.node.ID)
 	}
 
 	return nil

--- a/client/cobs-wrapper.go
+++ b/client/cobs-wrapper.go
@@ -167,13 +167,13 @@ func (cw *CobsWrapper) Read(b []byte) (int, error) {
 
 func (cw *CobsWrapper) Write(b []byte) (int, error) {
 	if cw.debug >= 8 {
-		log.Println("SER TX RAW: ", test.HexDump(b))
+		log.Println("SER TX RAW:", test.HexDump(b))
 	}
 
 	w := append([]byte{0}, cobs.Encode(b)...)
 
 	if cw.debug >= 9 {
-		log.Println("SER TX COBS: ", test.HexDump(w))
+		log.Println("SER TX COBS:", test.HexDump(w))
 	}
 
 	return cw.dev.Write(w)

--- a/client/db.go
+++ b/client/db.go
@@ -50,7 +50,7 @@ func NewDbClient(nc *nats.Conn, config Db) Client {
 
 // Run runs the main logic for this client and blocks until stopped
 func (dbc *DbClient) Run() error {
-	log.Println("Starting db client: ", dbc.config.Description)
+	log.Println("Starting db client:", dbc.config.Description)
 
 	// FIXME, we probably want to store edge points too ...
 	subject := fmt.Sprintf("up.%v.*", dbc.config.Parent)
@@ -59,14 +59,14 @@ func (dbc *DbClient) Run() error {
 	dbc.upSub, err = dbc.nc.Subscribe(subject, func(msg *nats.Msg) {
 		points, err := data.PbDecodePoints(msg.Data)
 		if err != nil {
-			log.Println("Error decoding points in db upSub: ", err)
+			log.Println("Error decoding points in db upSub:", err)
 			return
 		}
 
 		// find node ID for points
 		chunks := strings.Split(msg.Subject, ".")
 		if len(chunks) != 3 {
-			log.Println("rule client up sub, malformed subject: ", msg.Subject)
+			log.Println("rule client up sub, malformed subject:", msg.Subject)
 			return
 		}
 
@@ -83,7 +83,7 @@ func (dbc *DbClient) Run() error {
 		// find node ID for points
 		chunks := strings.Split(msg.Subject, ".")
 		if len(chunks) != 3 {
-			log.Println("rule client up hr sub, malformed subject: ", msg.Subject)
+			log.Println("rule client up hr sub, malformed subject:", msg.Subject)
 			return
 		}
 
@@ -104,7 +104,7 @@ func (dbc *DbClient) Run() error {
 		})
 
 		if err != nil {
-			log.Println("DB: error decoding HR data: ", err)
+			log.Println("DB: error decoding HR data:", err)
 		}
 	})
 
@@ -124,7 +124,7 @@ func (dbc *DbClient) Run() error {
 		go func() {
 			for err := range influxErrors {
 				if err != nil {
-					log.Println("Influx write error: ", err)
+					log.Println("Influx write error:", err)
 				}
 
 			}
@@ -138,12 +138,12 @@ done:
 	for {
 		select {
 		case <-dbc.stop:
-			log.Println("Stopping db client: ", dbc.config.Description)
+			log.Println("Stopping db client:", dbc.config.Description)
 			break done
 		case pts := <-dbc.newPoints:
 			err := data.MergePoints(pts.ID, pts.Points, &dbc.config)
 			if err != nil {
-				log.Println("error merging new points: ", err)
+				log.Println("error merging new points:", err)
 			}
 
 			for _, p := range pts.Points {
@@ -161,7 +161,7 @@ done:
 		case pts := <-dbc.newEdgePoints:
 			err := data.MergeEdgePoints(pts.ID, pts.Parent, pts.Points, &dbc.config)
 			if err != nil {
-				log.Println("error merging new points: ", err)
+				log.Println("error merging new points:", err)
 			}
 		case pts := <-dbc.newDbPoints:
 			for _, point := range pts.Points {

--- a/client/debug.go
+++ b/client/debug.go
@@ -96,64 +96,64 @@ func Log(natsServer, authToken string) {
 	nc, err := EdgeConnect(opts)
 
 	if err != nil {
-		log.Println("Error connecting to NATS server: ", err)
+		log.Println("Error connecting to NATS server:", err)
 		os.Exit(-1)
 	}
 
 	_, _ = nc.Subscribe("p.*", func(msg *nats.Msg) {
 		err := Dump(nc, msg)
 		if err != nil {
-			log.Println("Error dumping nats msg: ", err)
+			log.Println("Error dumping nats msg:", err)
 		}
 	})
 
 	_, _ = nc.Subscribe("node.*.not", func(msg *nats.Msg) {
 		err := Dump(nc, msg)
 		if err != nil {
-			log.Println("Error dumping nats msg: ", err)
+			log.Println("Error dumping nats msg:", err)
 		}
 	})
 
 	_, _ = nc.Subscribe("node.*.msg", func(msg *nats.Msg) {
 		err := Dump(nc, msg)
 		if err != nil {
-			log.Println("Error dumping nats msg: ", err)
+			log.Println("Error dumping nats msg:", err)
 		}
 	})
 
 	_, _ = nc.Subscribe("p.*.*", func(msg *nats.Msg) {
 		err := Dump(nc, msg)
 		if err != nil {
-			log.Println("Error dumping nats msg: ", err)
+			log.Println("Error dumping nats msg:", err)
 		}
 	})
 
 	if err != nil {
-		log.Println("Nats subscribe error: ", err)
+		log.Println("Nats subscribe error:", err)
 		os.Exit(-1)
 	}
 
 	_, err = nc.Subscribe("node.*", func(msg *nats.Msg) {
 		err := Dump(nc, msg)
 		if err != nil {
-			log.Println("Error dumping nats msg: ", err)
+			log.Println("Error dumping nats msg:", err)
 		}
 	})
 
 	if err != nil {
-		log.Println("Nats subscribe error: ", err)
+		log.Println("Nats subscribe error:", err)
 		os.Exit(-1)
 	}
 
 	_, err = nc.Subscribe("edge.*.*", func(msg *nats.Msg) {
 		err := Dump(nc, msg)
 		if err != nil {
-			log.Println("Error dumping nats msg: ", err)
+			log.Println("Error dumping nats msg:", err)
 		}
 	})
 
 	if err != nil {
-		log.Println("Nats subscribe error: ", err)
+		log.Println("Nats subscribe error:", err)
 		os.Exit(-1)
 	}
 }

--- a/client/edge.go
+++ b/client/edge.go
@@ -41,7 +41,7 @@ func EdgeConnect(eo EdgeOptions) (*nats.Conn, error) {
 				pendingMsgs, sub.Subject)
 			// Log error, notify operations...
 		default:
-			log.Println("Nats client error: ", natsErr)
+			log.Println("Nats client error:", natsErr)
 		}
 		// check for other errors
 	}
@@ -122,7 +122,7 @@ func EdgeConnect(eo EdgeOptions) (*nats.Conn, error) {
 		return nil, err
 	}
 
-	log.Println("NATS: TLS required: ", nc.TLSRequired())
+	log.Println("NATS: TLS required:", nc.TLSRequired())
 
 	return nc, nil
 }

--- a/client/example_manager_test.go
+++ b/client/example_manager_test.go
@@ -52,13 +52,13 @@ func (tnc *exNodeClient) Run() error {
 		case pts := <-tnc.newPoints:
 			err := data.MergePoints(pts.ID, pts.Points, &tnc.config)
 			if err != nil {
-				log.Println("error merging new points: ", err)
+				log.Println("error merging new points:", err)
 			}
 			log.Printf("New config: %+v\n", tnc.config)
 		case pts := <-tnc.newEdgePoints:
 			err := data.MergeEdgePoints(pts.ID, pts.Parent, pts.Points, &tnc.config)
 			if err != nil {
-				log.Println("error merging new points: ", err)
+				log.Println("error merging new points:", err)
 			}
 		case ch := <-tnc.chGetConfig:
 			ch <- tnc.config
@@ -87,7 +87,7 @@ func ExampleNewManager() {
 	nc, root, stop, err := server.TestServer()
 
 	if err != nil {
-		log.Println("Error starting test server: ", err)
+		log.Println("Error starting test server:", err)
 	}
 
 	defer stop()
@@ -97,7 +97,7 @@ func ExampleNewManager() {
 	// Convert our custom struct to a data.NodeEdge struct
 	ne, err := data.Encode(testConfig)
 	if err != nil {
-		log.Println("Error encoding node: ", err)
+		log.Println("Error encoding node:", err)
 	}
 
 	ne.Parent = root.ID
@@ -106,7 +106,7 @@ func ExampleNewManager() {
 	err = client.SendNode(nc, ne, "test")
 
 	if err != nil {
-		log.Println("Error sending node: ", err)
+		log.Println("Error sending node:", err)
 	}
 
 	// Create a new manager for nodes of type "testNode". The manager looks for new nodes under the
@@ -115,7 +115,7 @@ func ExampleNewManager() {
 	err = m.Run()
 
 	if err != nil {
-		log.Println("Error running: ", err)
+		log.Println("Error running:", err)
 	}
 
 	// Now any updates to the node will trigger Points/EdgePoints callbacks in the above client

--- a/client/file-transfer.go
+++ b/client/file-transfer.go
@@ -32,10 +32,10 @@ func ListenForFile(nc *nats.Conn, dir, deviceID string, callback func(path strin
 		err := proto.Unmarshal(m.Data, chunk)
 
 		if err != nil {
-			log.Println("Error decoding file chunk: ", err)
+			log.Println("Error decoding file chunk:", err)
 			err := nc.Publish(m.Reply, []byte("error decoding"))
 			if err != nil {
-				log.Println("Error replying to file download: ", err)
+				log.Println("Error replying to file download:", err)
 				return
 			}
 		}
@@ -46,10 +46,10 @@ func ListenForFile(nc *nats.Conn, dir, deviceID string, callback func(path strin
 			dl.data = []byte{}
 			dl.seq = 0
 		} else if chunk.Seq != dl.seq+1 {
-			log.Println("Seq # error in file download: ", dl.seq, chunk.Seq)
+			log.Println("Seq # error in file download:", dl.seq, chunk.Seq)
 			err := nc.Publish(m.Reply, []byte("seq error"))
 			if err != nil {
-				log.Println("Error replying to file download: ", err)
+				log.Println("Error replying to file download:", err)
 				return
 			}
 		}
@@ -67,10 +67,10 @@ func ListenForFile(nc *nats.Conn, dir, deviceID string, callback func(path strin
 			filePath := path.Join(dir, dl.name)
 			err := os.WriteFile(filePath, dl.data, 0644)
 			if err != nil {
-				log.Println("Error writing dl file: ", err)
+				log.Println("Error writing dl file:", err)
 				err := nc.Publish(m.Reply, []byte("error writing"))
 				if err != nil {
-					log.Println("Error replying to file download: ", err)
+					log.Println("Error replying to file download:", err)
 					return
 				}
 			}
@@ -80,7 +80,7 @@ func ListenForFile(nc *nats.Conn, dir, deviceID string, callback func(path strin
 
 		err = nc.Publish(m.Reply, []byte("OK"))
 		if err != nil {
-			log.Println("Error replying to file download: ", err)
+			log.Println("Error replying to file download:", err)
 		}
 	})
 
@@ -129,14 +129,14 @@ func SendFile(nc *nats.Conn, deviceID string, reader io.Reader, name string, cal
 			msg, err := nc.Request(subject, out, time.Minute)
 
 			if err != nil {
-				log.Println("Error sending file, retrying: ", retry, err)
+				log.Println("Error sending file, retrying:", retry, err)
 				continue
 			}
 
 			msgS := string(msg.Data)
 
 			if msgS != "OK" {
-				log.Println("Error from device when sending file: ", retry, msgS)
+				log.Println("Error from device when sending file:", retry, msgS)
 				continue
 			}
 

--- a/client/manager.go
+++ b/client/manager.go
@@ -98,7 +98,7 @@ func (m *Manager[T]) Run() error {
 
 	err = m.scan(m.root)
 	if err != nil {
-		log.Println("Error scanning for new nodes: ", err)
+		log.Println("Error scanning for new nodes:", err)
 	}
 
 	shutdownTimer := time.NewTimer(time.Hour)
@@ -116,7 +116,7 @@ func (m *Manager[T]) Run() error {
 
 		err := m.scan(m.root)
 		if err != nil {
-			log.Println("Error scanning for new nodes: ", err)
+			log.Println("Error scanning for new nodes:", err)
 		}
 	}
 
@@ -146,7 +146,7 @@ done:
 			// work reliably without deadlocking
 			err = m.clientUpSub[key].Drain()
 			if err != nil {
-				log.Println("Error unsubscribing subscription: ", err)
+				log.Println("Error unsubscribing subscription:", err)
 			}
 			start := time.Now()
 			for {
@@ -154,7 +154,7 @@ done:
 					break
 				}
 				if time.Since(start) > time.Second*1 {
-					log.Println("Error: timeout waiting for subscription to drain: ", key)
+					log.Println("Error: timeout waiting for subscription to drain:", key)
 					break
 				}
 				time.Sleep(10 * time.Millisecond)
@@ -164,7 +164,7 @@ done:
 		case key := <-m.chDeleteCS:
 			err = m.clientUpSub[key].Unsubscribe()
 			if err != nil {
-				log.Println("Error unsubscribing subscription: ", err)
+				log.Println("Error unsubscribing subscription:", err)
 			}
 			delete(m.clientUpSub, key)
 			// client state must be deleted after the subscription is stopped
@@ -182,9 +182,9 @@ done:
 			}
 		case <-shutdownTimer.C:
 			// TODO: should we return an error here?
-			log.Println("BUG: Client manager: not all clients shutdown for node type: ", m.nodeType)
+			log.Println("BUG: Client manager: not all clients shutdown for node type:", m.nodeType)
 			for _, v := range m.clientStates {
-				log.Println("Client stuck for node: ", v.node.ID)
+				log.Println("Client stuck for node:", v.node.ID)
 			}
 			break done
 		}
@@ -278,7 +278,7 @@ func (m *Manager[T]) scan(id string) error {
 			chunks := strings.Split(msg.Subject, ".")
 
 			if len(chunks) != 3 && len(chunks) != 4 {
-				log.Println("up subject malformed: ", msg.Subject)
+				log.Println("up subject malformed:", msg.Subject)
 				return
 			}
 
@@ -322,7 +322,7 @@ func (m *Manager[T]) scan(id string) error {
 							}
 							nodes, err := GetNodes(cs.nc, parentID, nodeID, "", false)
 							if err != nil {
-								log.Println("Client state error getting nodes: ", err)
+								log.Println("Client state error getting nodes:", err)
 								cs.stop(nil)
 								return
 							}
@@ -347,7 +347,7 @@ func (m *Manager[T]) scan(id string) error {
 							}
 							nodes, err := GetNodes(cs.nc, parentID, nodeID, "", false)
 							if err != nil {
-								log.Println("Client state error getting nodes: ", err)
+								log.Println("Client state error getting nodes:", err)
 								cs.stop(nil)
 								return
 							}
@@ -382,7 +382,7 @@ func (m *Manager[T]) scan(id string) error {
 		}
 
 		// bus was deleted so close and clear it
-		log.Println("removing client node: ", m.clientStates[key].node.ID)
+		log.Println("removing client node:", m.clientStates[key].node.ID)
 		client.stop(nil)
 	}
 

--- a/client/manager_test.go
+++ b/client/manager_test.go
@@ -51,12 +51,12 @@ func (tnc *testNodeClient) Run() error {
 		case pts := <-tnc.newPoints:
 			err := data.MergePoints(pts.ID, pts.Points, &tnc.config)
 			if err != nil {
-				log.Println("error merging new points: ", err)
+				log.Println("error merging new points:", err)
 			}
 		case pts := <-tnc.newEdgePoints:
 			err := data.MergeEdgePoints(pts.ID, pts.Parent, pts.Points, &tnc.config)
 			if err != nil {
-				log.Println("error merging new points: ", err)
+				log.Println("error merging new points:", err)
 			}
 		case ch := <-tnc.chGetConfig:
 			ch <- tnc.config
@@ -345,12 +345,12 @@ func (tnc *testXClient) Run() error {
 		case pts := <-tnc.newPoints:
 			err := data.MergePoints(pts.ID, pts.Points, &tnc.config)
 			if err != nil {
-				log.Println("error merging new points: ", err)
+				log.Println("error merging new points:", err)
 			}
 		case pts := <-tnc.newEdgePoints:
 			err := data.MergeEdgePoints(pts.ID, pts.Parent, pts.Points, &tnc.config)
 			if err != nil {
-				log.Println("error merging new points: ", err)
+				log.Println("error merging new points:", err)
 			}
 		case ch := <-tnc.chGetConfig:
 			ch <- tnc.config

--- a/client/metrics.go
+++ b/client/metrics.go
@@ -63,7 +63,7 @@ func (m *MetricsClient) Run() error {
 
 			err := SendPoints(m.nc, SubjectNodePoints(m.config.ID), points, false)
 			if err != nil {
-				log.Println("Error sending metrics period: ", err)
+				log.Println("Error sending metrics period:", err)
 			}
 		}
 	}
@@ -95,7 +95,7 @@ done:
 		case pts := <-m.newPoints:
 			err := data.MergePoints(pts.ID, pts.Points, &m.config)
 			if err != nil {
-				log.Println("error merging new points: ", err)
+				log.Println("error merging new points:", err)
 			}
 
 			for _, p := range pts.Points {
@@ -114,7 +114,7 @@ done:
 		case pts := <-m.newEdgePoints:
 			err := data.MergeEdgePoints(pts.ID, pts.Parent, pts.Points, &m.config)
 			if err != nil {
-				log.Println("error merging new points: ", err)
+				log.Println("error merging new points:", err)
 			}
 
 		}
@@ -145,7 +145,7 @@ func (m *MetricsClient) sysStart() {
 	// collect static host stats on startup
 	hostStat, err := host.Info()
 	if err != nil {
-		log.Println("Metrics error: ", err)
+		log.Println("Metrics error:", err)
 	} else {
 		// TODO, only send points if they have changed
 		pts := data.Points{
@@ -211,13 +211,13 @@ func (m *MetricsClient) sysStart() {
 		}
 		err = SendNodePoints(m.nc, m.config.ID, pts, false)
 		if err != nil {
-			log.Println("Metrics: error sending points: ", err)
+			log.Println("Metrics: error sending points:", err)
 		}
 	}
 
 	vm, err := mem.VirtualMemory()
 	if err != nil {
-		log.Println("Metrics error: ", err)
+		log.Println("Metrics error:", err)
 	} else {
 		pt := data.Point{
 			Type:  data.PointTypeMetricSysMem,
@@ -228,7 +228,7 @@ func (m *MetricsClient) sysStart() {
 
 		err = SendNodePoint(m.nc, m.config.ID, pt, false)
 		if err != nil {
-			log.Println("Metrics: error sending points: ", err)
+			log.Println("Metrics: error sending points:", err)
 		}
 	}
 
@@ -240,7 +240,7 @@ func (m *MetricsClient) sysPeriodic() {
 
 	avg, err := load.Avg()
 	if err != nil {
-		log.Println("Metrics error: ", err)
+		log.Println("Metrics error:", err)
 	} else {
 		pts = append(pts, data.Points{
 			{
@@ -267,7 +267,7 @@ func (m *MetricsClient) sysPeriodic() {
 
 	perc, err := cpu.Percent(time.Duration(m.config.Period)*time.Second, false)
 	if err != nil {
-		log.Println("Metrics error: ", err)
+		log.Println("Metrics error:", err)
 	} else {
 		pts = append(pts, data.Point{Type: data.PointTypeMetricSysCPUPercent,
 			Time:  now,
@@ -277,7 +277,7 @@ func (m *MetricsClient) sysPeriodic() {
 
 	vm, err := mem.VirtualMemory()
 	if err != nil {
-		log.Println("Metrics error: ", err)
+		log.Println("Metrics error:", err)
 	} else {
 		pts = append(pts, data.Points{
 			{
@@ -308,7 +308,7 @@ func (m *MetricsClient) sysPeriodic() {
 
 	parts, err := disk.Partitions(false)
 	if err != nil {
-		log.Println("Metrics error: ", err)
+		log.Println("Metrics error:", err)
 	} else {
 		for _, p := range parts {
 			if strings.HasPrefix(p.Mountpoint, "/run/media") {
@@ -318,7 +318,7 @@ func (m *MetricsClient) sysPeriodic() {
 
 			u, err := disk.Usage(p.Mountpoint)
 			if err != nil {
-				log.Println("Error getting disk usage: ", err)
+				log.Println("Error getting disk usage:", err)
 				continue
 			}
 			pts = append(pts, data.Points{
@@ -334,7 +334,7 @@ func (m *MetricsClient) sysPeriodic() {
 
 	netio, err := net.IOCounters(true)
 	if err != nil {
-		log.Println("Metrics error: ", err)
+		log.Println("Metrics error:", err)
 	} else {
 		for _, io := range netio {
 			pts = append(pts, data.Points{
@@ -357,7 +357,7 @@ func (m *MetricsClient) sysPeriodic() {
 
 	uptime, err := host.Uptime()
 	if err != nil {
-		log.Println("Metrics error: ", err)
+		log.Println("Metrics error:", err)
 	} else {
 		pts = append(pts, data.Point{
 			Time:  now,
@@ -368,7 +368,7 @@ func (m *MetricsClient) sysPeriodic() {
 
 	temps, err := host.SensorsTemperatures()
 	if err != nil {
-		log.Println("Error reading sensors: ", err)
+		log.Println("Error reading sensors:", err)
 	} else {
 		for _, t := range temps {
 			pts = append(pts, data.Points{
@@ -384,7 +384,7 @@ func (m *MetricsClient) sysPeriodic() {
 
 	err = SendNodePoints(m.nc, m.config.ID, pts, false)
 	if err != nil {
-		log.Println("Metrics: error sending points: ", err)
+		log.Println("Metrics: error sending points:", err)
 	}
 }
 
@@ -414,7 +414,7 @@ func (m *MetricsClient) appPeriodic(procName string) {
 
 		err := SendNodePoints(m.nc, m.config.ID, pts, false)
 		if err != nil {
-			log.Println("Metrics: error sending points: ", err)
+			log.Println("Metrics: error sending points:", err)
 		}
 	}
 
@@ -422,7 +422,7 @@ func (m *MetricsClient) appPeriodic(procName string) {
 
 	procs, err := process.Processes()
 	if err != nil {
-		log.Println("Metrics error: ", err)
+		log.Println("Metrics error:", err)
 	} else {
 		var accumCPUPerc, accumMemPerc, accumMemRSS float64
 		var procCount int
@@ -430,7 +430,7 @@ func (m *MetricsClient) appPeriodic(procName string) {
 			if procName != "" {
 				name, err := p.Name()
 				if err != nil {
-					log.Println("Error getting process name: ", err)
+					log.Println("Error getting process name:", err)
 					continue
 				}
 				if name != procName {
@@ -446,7 +446,7 @@ func (m *MetricsClient) appPeriodic(procName string) {
 
 			cpuPerc, err := p.CPUPercent()
 			if err != nil {
-				log.Println("Error getting CPU percent for proc: ", err)
+				log.Println("Error getting CPU percent for proc:", err)
 				break
 			}
 
@@ -454,7 +454,7 @@ func (m *MetricsClient) appPeriodic(procName string) {
 
 			memPerc, err := p.MemoryPercent()
 			if err != nil {
-				log.Println("Error getting mem percent for proc: ", err)
+				log.Println("Error getting mem percent for proc:", err)
 				break
 			}
 
@@ -462,7 +462,7 @@ func (m *MetricsClient) appPeriodic(procName string) {
 
 			memInfo, err := p.MemoryInfo()
 			if err != nil {
-				log.Println("Error getting mem info: ", err)
+				log.Println("Error getting mem info:", err)
 				break
 			}
 
@@ -497,7 +497,7 @@ func (m *MetricsClient) appPeriodic(procName string) {
 
 		err = SendNodePoints(m.nc, m.config.ID, pts, false)
 		if err != nil {
-			log.Println("Metrics: error sending points: ", err)
+			log.Println("Metrics: error sending points:", err)
 		}
 
 	}
@@ -517,12 +517,12 @@ func (m *MetricsClient) allProcPeriodic() {
 
 	procs, err := process.Processes()
 	if err != nil {
-		log.Println("Metrics error: ", err)
+		log.Println("Metrics error:", err)
 	} else {
 		for _, p := range procs {
 			name, err := p.Name()
 			if err != nil {
-				log.Println("Error getting process name: ", err)
+				log.Println("Error getting process name:", err)
 				continue
 			}
 
@@ -532,7 +532,7 @@ func (m *MetricsClient) allProcPeriodic() {
 
 			cpuPerc, err := p.CPUPercent()
 			if err != nil {
-				log.Println("Error getting CPU percent for proc: ", err)
+				log.Println("Error getting CPU percent for proc:", err)
 				break
 			}
 
@@ -540,7 +540,7 @@ func (m *MetricsClient) allProcPeriodic() {
 
 			memPerc, err := p.MemoryPercent()
 			if err != nil {
-				log.Println("Error getting mem percent for proc: ", err)
+				log.Println("Error getting mem percent for proc:", err)
 				break
 			}
 
@@ -548,7 +548,7 @@ func (m *MetricsClient) allProcPeriodic() {
 
 			memInfo, err := p.MemoryInfo()
 			if err != nil {
-				log.Println("Error getting mem info: ", err)
+				log.Println("Error getting mem info:", err)
 				break
 			}
 
@@ -587,7 +587,7 @@ func (m *MetricsClient) allProcPeriodic() {
 
 		err = SendNodePoints(m.nc, m.config.ID, pts, false)
 		if err != nil {
-			log.Println("Metrics: error sending points: ", err)
+			log.Println("Metrics: error sending points:", err)
 		}
 	}
 }

--- a/client/msg.go
+++ b/client/msg.go
@@ -18,7 +18,7 @@ func DecodeNodePointsMsg(msg *nats.Msg) (string, []data.Point, error) {
 	nodeID := chunks[1]
 	points, err := data.PbDecodePoints(msg.Data)
 	if err != nil {
-		log.Println("Error decoding Pb points: ", err)
+		log.Println("Error decoding Pb points:", err)
 		return "", []data.Point{}, fmt.Errorf("Error decoding Pb points: %w", err)
 	}
 
@@ -36,7 +36,7 @@ func DecodeEdgePointsMsg(msg *nats.Msg) (string, string, []data.Point, error) {
 	parentID := chunks[2]
 	points, err := data.PbDecodePoints(msg.Data)
 	if err != nil {
-		log.Println("Error decoding Pb points: ", err)
+		log.Println("Error decoding Pb points:", err)
 		return "", "", []data.Point{}, fmt.Errorf("Error decoding Pb points: %w", err)
 	}
 
@@ -54,7 +54,7 @@ func DecodeUpNodePointsMsg(msg *nats.Msg) (string, string, []data.Point, error) 
 	nodeID := chunks[2]
 	points, err := data.PbDecodePoints(msg.Data)
 	if err != nil {
-		log.Println("Error decoding Pb points: ", err)
+		log.Println("Error decoding Pb points:", err)
 		return "", "", []data.Point{}, fmt.Errorf("Error decoding Pb points: %w", err)
 	}
 
@@ -73,7 +73,7 @@ func DecodeUpEdgePointsMsg(msg *nats.Msg) (string, string, string, []data.Point,
 	parentID := chunks[3]
 	points, err := data.PbDecodePoints(msg.Data)
 	if err != nil {
-		log.Println("Error decoding Pb points: ", err)
+		log.Println("Error decoding Pb points:", err)
 		return "", "", "", []data.Point{}, fmt.Errorf("Error decoding Pb points: %w", err)
 	}
 

--- a/client/network-manager.go
+++ b/client/network-manager.go
@@ -253,7 +253,7 @@ loop:
 			// Update config
 			err := data.MergePoints(nodePoints.ID, nodePoints.Points, &c.config)
 			if err != nil {
-				log.Println("Error merging points: ", err)
+				log.Println("Error merging points:", err)
 			}
 
 			// Handle Disable flag

--- a/client/node.go
+++ b/client/node.go
@@ -81,7 +81,7 @@ func GetNodesType[T any](nc *nats.Conn, parent, id string) ([]T, error) {
 	for i, n := range nodes {
 		err := data.Decode(data.NodeEdgeChildren{NodeEdge: n, Children: nil}, &ret[i])
 		if err != nil {
-			log.Println("Error decode node in GetNodeType: ", err)
+			log.Println("Error decode node in GetNodeType:", err)
 		}
 	}
 
@@ -406,12 +406,12 @@ func NodeWatcher[T any](nc *nats.Conn, id, parent string) (get func() T, stop fu
 			case pts := <-pointUpdates:
 				err := data.MergePoints(id, pts, &current)
 				if err != nil {
-					log.Println("NodeWatcher, error merging points: ", err)
+					log.Println("NodeWatcher, error merging points:", err)
 				}
 			case pts := <-edgeUpdates:
 				err := data.MergeEdgePoints(id, parent, pts, &current)
 				if err != nil {
-					log.Println("NodeWatcher, error merging edge points: ", err)
+					log.Println("NodeWatcher, error merging edge points:", err)
 				}
 			}
 		}

--- a/client/particle.go
+++ b/client/particle.go
@@ -70,7 +70,7 @@ func NewParticleClient(nc *nats.Conn, config Particle) Client {
 
 // Run runs the main logic for this client and blocks until stopped
 func (pc *ParticleClient) Run() error {
-	log.Println("Starting particle client: ", pc.config.Description)
+	log.Println("Starting particle client:", pc.config.Description)
 
 	closeReader := make(chan struct{})  // is closed to close reader
 	readerClosed := make(chan struct{}) // struct{} is sent when reader exits
@@ -86,7 +86,7 @@ func (pc *ParticleClient) Run() error {
 		stream, err := eventsource.Subscribe(urlAuth, "")
 
 		if err != nil {
-			log.Println("Particle subscription error: ", err)
+			log.Println("Particle subscription error:", err)
 			return
 		}
 
@@ -96,14 +96,14 @@ func (pc *ParticleClient) Run() error {
 				var pEvent ParticleEvent
 				err := json.Unmarshal([]byte(event.Data()), &pEvent)
 				if err != nil {
-					log.Println("Got error decoding particle event: ", err)
+					log.Println("Got error decoding particle event:", err)
 					continue
 				}
 
 				var pPoints []particlePoint
 				err = json.Unmarshal([]byte(pEvent.Data), &pPoints)
 				if err != nil {
-					log.Println("error decoding Particle samples: ", err)
+					log.Println("error decoding Particle samples:", err)
 					continue
 				}
 
@@ -116,11 +116,11 @@ func (pc *ParticleClient) Run() error {
 
 				err = SendNodePoints(pc.nc, pc.config.ID, points, false)
 				if err != nil {
-					log.Println("Particle error sending points: ", err)
+					log.Println("Particle error sending points:", err)
 				}
 
 			case err := <-stream.Errors:
-				log.Println("Particle error: ", err)
+				log.Println("Particle error:", err)
 
 			case <-closeReader:
 				log.Println("Exiting particle reader")
@@ -154,12 +154,12 @@ done:
 	for {
 		select {
 		case <-pc.stop:
-			log.Println("Stopping particle client: ", pc.config.Description)
+			log.Println("Stopping particle client:", pc.config.Description)
 			break done
 		case pts := <-pc.newPoints:
 			err := data.MergePoints(pts.ID, pts.Points, &pc.config)
 			if err != nil {
-				log.Println("error merging new points: ", err)
+				log.Println("error merging new points:", err)
 			}
 
 			for _, p := range pts.Points {
@@ -179,7 +179,7 @@ done:
 		case pts := <-pc.newEdgePoints:
 			err := data.MergeEdgePoints(pts.ID, pts.Parent, pts.Points, &pc.config)
 			if err != nil {
-				log.Println("error merging new points: ", err)
+				log.Println("error merging new points:", err)
 			}
 
 		case <-readerClosed:

--- a/client/point.go
+++ b/client/point.go
@@ -74,7 +74,7 @@ func SubscribePoints(nc *nats.Conn, id string, callback func(points []data.Point
 	psub, err := nc.Subscribe(SubjectNodePoints(id), func(msg *nats.Msg) {
 		points, err := data.PbDecodePoints(msg.Data)
 		if err != nil {
-			log.Println("Error decoding points: ", err)
+			log.Println("Error decoding points:", err)
 			return
 		}
 
@@ -84,7 +84,7 @@ func SubscribePoints(nc *nats.Conn, id string, callback func(points []data.Point
 	return func() {
 		err := psub.Unsubscribe()
 		if err != nil {
-			log.Println("Unsubscribe points error: ", err)
+			log.Println("Unsubscribe points error:", err)
 		}
 	}, err
 }
@@ -95,7 +95,7 @@ func SubscribeEdgePoints(nc *nats.Conn, id, parent string, callback func(points 
 	psub, err := nc.Subscribe(SubjectEdgePoints(id, parent), func(msg *nats.Msg) {
 		points, err := data.PbDecodePoints(msg.Data)
 		if err != nil {
-			log.Println("Error decoding points: ", err)
+			log.Println("Error decoding points:", err)
 			return
 		}
 
@@ -105,7 +105,7 @@ func SubscribeEdgePoints(nc *nats.Conn, id, parent string, callback func(points 
 	return func() {
 		err := psub.Unsubscribe()
 		if err != nil {
-			log.Println("Unsubscribe points error: ", err)
+			log.Println("Unsubscribe points error:", err)
 		}
 	}, err
 }

--- a/client/rule.go
+++ b/client/rule.go
@@ -215,14 +215,14 @@ func (rc *RuleClient) Run() error {
 	rc.upSub, err = rc.nc.Subscribe(subject, func(msg *nats.Msg) {
 		points, err := data.PbDecodePoints(msg.Data)
 		if err != nil {
-			log.Println("Error decoding points in rule upSub: ", err)
+			log.Println("Error decoding points in rule upSub:", err)
 			return
 		}
 
 		// find node ID for points
 		chunks := strings.Split(msg.Subject, ".")
 		if len(chunks) != 3 {
-			log.Println("rule client up sub, malformed subject: ", msg.Subject)
+			log.Println("rule client up sub, malformed subject:", msg.Subject)
 			return
 		}
 
@@ -249,7 +249,7 @@ func (rc *RuleClient) Run() error {
 		if len(pts) > 0 {
 			active, changed, err = rc.ruleProcessPoints(id, pts)
 			if err != nil {
-				log.Println("Error processing rule point: ", err)
+				log.Println("Error processing rule point:", err)
 			}
 
 			if !changed {
@@ -263,29 +263,29 @@ func (rc *RuleClient) Run() error {
 				Type: data.PointTypeTrigger,
 			}})
 			if err != nil {
-				log.Println("Error processing rule point: ", err)
+				log.Println("Error processing rule point:", err)
 			}
 		}
 
 		if active {
 			err := rc.ruleRunActions(rc.config.Actions, id)
 			if err != nil {
-				log.Println("Error running rule actions: ", err)
+				log.Println("Error running rule actions:", err)
 			}
 
 			err = rc.ruleInactiveActions(rc.config.ActionsInactive)
 			if err != nil {
-				log.Println("Error running rule inactive actions: ", err)
+				log.Println("Error running rule inactive actions:", err)
 			}
 		} else {
 			err := rc.ruleRunActions(rc.config.ActionsInactive, id)
 			if err != nil {
-				log.Println("Error running rule actions: ", err)
+				log.Println("Error running rule actions:", err)
 			}
 
 			err = rc.ruleInactiveActions(rc.config.Actions)
 			if err != nil {
-				log.Println("Error running rule inactive actions: ", err)
+				log.Println("Error running rule inactive actions:", err)
 			}
 		}
 	}
@@ -307,7 +307,7 @@ done:
 		case pts := <-rc.newPoints:
 			err := data.MergePoints(pts.ID, pts.Points, &rc.config)
 			if err != nil {
-				log.Println("error merging rule points: ", err)
+				log.Println("error merging rule points:", err)
 			}
 			if rc.hasSchedule() {
 				scheduleTicker = time.NewTicker(scheduleTickTime)
@@ -319,7 +319,7 @@ done:
 		case pts := <-rc.newEdgePoints:
 			err := data.MergeEdgePoints(pts.ID, pts.Parent, pts.Points, &rc.config)
 			if err != nil {
-				log.Println("error merging rule edge points: ", err)
+				log.Println("error merging rule edge points:", err)
 			}
 			run("", nil)
 		}
@@ -379,7 +379,7 @@ func (rc *RuleClient) processError(errS string) {
 
 			err := rc.sendPoint(rc.config.ID, p)
 			if err != nil {
-				log.Println("Rule error sending point: ", err)
+				log.Println("Rule error sending point:", err)
 			} else {
 				rc.config.Error = errS
 			}
@@ -418,7 +418,7 @@ func (rc *RuleClient) processError(errS string) {
 
 			err := rc.sendPoint(rc.config.ID, p)
 			if err != nil {
-				log.Println("Rule error sending point: ", err)
+				log.Println("Rule error sending point:", err)
 			} else {
 				rc.config.Error = found
 			}
@@ -449,7 +449,7 @@ func (rc *RuleClient) ruleProcessPoints(nodeID string, points data.Points) (bool
 					log.Printf("Rule cond error %v:%v:%v\n", rc.config.Description, c.Description, err)
 					err := rc.sendPoint(c.ID, p)
 					if err != nil {
-						log.Println("Rule error sending point: ", err)
+						log.Println("Rule error sending point:", err)
 					} else {
 						rc.config.Conditions[i].Error = errS
 					}
@@ -528,7 +528,7 @@ func (rc *RuleClient) ruleProcessPoints(nodeID string, points data.Points) (bool
 
 				err := rc.sendPoint(c.ID, p)
 				if err != nil {
-					log.Println("Rule error sending point: ", err)
+					log.Println("Rule error sending point:", err)
 				}
 
 				rc.config.Conditions[i].Active = active
@@ -543,7 +543,7 @@ func (rc *RuleClient) ruleProcessPoints(nodeID string, points data.Points) (bool
 
 				err := rc.sendPoint(c.ID, p)
 				if err != nil {
-					log.Println("Rule error sending point: ", err)
+					log.Println("Rule error sending point:", err)
 				} else {
 					rc.config.Conditions[i].Error = ""
 				}
@@ -572,7 +572,7 @@ func (rc *RuleClient) ruleProcessPoints(nodeID string, points data.Points) (bool
 
 		err := rc.sendPoint(rc.config.ID, p)
 		if err != nil {
-			log.Println("Rule error sending point: ", err)
+			log.Println("Rule error sending point:", err)
 		}
 		changed = true
 
@@ -600,7 +600,7 @@ func (rc *RuleClient) ruleRunActions(actions []Action, triggerNodeID string) err
 				log.Printf("Rule action error %v:%v:%v\n", rc.config.Description, a.Description, err)
 				err := rc.sendPoint(a.ID, p)
 				if err != nil {
-					log.Println("Rule error sending point: ", err)
+					log.Println("Rule error sending point:", err)
 				} else {
 					actions[i].Error = errS
 				}
@@ -629,7 +629,7 @@ func (rc *RuleClient) ruleRunActions(actions []Action, triggerNodeID string) err
 			}
 			err := rc.sendPoint(a.NodeID, p)
 			if err != nil {
-				log.Println("Error sending rule action point: ", err)
+				log.Println("Error sending rule action point:", err)
 			}
 		case data.PointValueNotify:
 			// get node that fired the rule
@@ -679,7 +679,7 @@ func (rc *RuleClient) ruleRunActions(actions []Action, triggerNodeID string) err
 			format := d.Format()
 
 			if format.SampleRate < 8000 {
-				log.Println("Rule action: invalid wave file sample rate: ", format.SampleRate)
+				log.Println("Rule action: invalid wave file sample rate:", format.SampleRate)
 				continue
 			}
 
@@ -689,7 +689,7 @@ func (rc *RuleClient) ruleRunActions(actions []Action, triggerNodeID string) err
 			go func() {
 				stderr, err := exec.Command("speaker-test", "-D"+a.PointDevice, "-twav", "-w"+a.PointFilePath, "-c5", "-s"+channelNum, "-r"+sampleRate).CombinedOutput()
 				if err != nil {
-					log.Println("Play audio error: ", err)
+					log.Println("Play audio error:", err)
 					log.Printf("Audio stderr: %s\n", stderr)
 				}
 			}()
@@ -703,7 +703,7 @@ func (rc *RuleClient) ruleRunActions(actions []Action, triggerNodeID string) err
 		}
 		err := rc.sendPoint(a.ID, p)
 		if err != nil {
-			log.Println("Error sending rule action point: ", err)
+			log.Println("Error sending rule action point:", err)
 		}
 
 		actions[i].Active = true
@@ -717,7 +717,7 @@ func (rc *RuleClient) ruleRunActions(actions []Action, triggerNodeID string) err
 
 			err := rc.sendPoint(a.ID, p)
 			if err != nil {
-				log.Println("Rule error sending point: ", err)
+				log.Println("Rule error sending point:", err)
 			} else {
 				actions[i].Error = ""
 			}
@@ -736,7 +736,7 @@ func (rc *RuleClient) ruleInactiveActions(actions []Action) error {
 		}
 		err := rc.sendPoint(a.ID, p)
 		if err != nil {
-			log.Println("Error sending rule action point: ", err)
+			log.Println("Error sending rule action point:", err)
 		}
 		actions[i].Active = false
 	}

--- a/client/serial.go
+++ b/client/serial.go
@@ -89,7 +89,7 @@ func (sd *SerialDevClient) populateNatsSubjects() {
 	if sd.parentSubscription != nil {
 		err := sd.parentSubscription.Unsubscribe()
 		if err != nil {
-			log.Println("Serial: error unsubscribing from parent sub: ", err)
+			log.Println("Serial: error unsubscribing from parent sub:", err)
 		}
 		sd.parentSubscription = nil
 	}
@@ -100,7 +100,7 @@ func (sd *SerialDevClient) populateNatsSubjects() {
 		sd.parentSubscription, err = sd.nc.Subscribe(sd.natsSubSerialPoints, func(msg *nats.Msg) {
 			points, err := data.PbDecodePoints(msg.Data)
 			if err != nil {
-				log.Println("Error decoding points in serial parent: ", err)
+				log.Println("Error decoding points in serial parent:", err)
 				return
 			}
 
@@ -124,12 +124,12 @@ func (sd *SerialDevClient) populateNatsSubjects() {
 				sd.wrSeq++
 				err := sd.sendPointsToDevice(sd.wrSeq, false, "", pointsToSend)
 				if err != nil {
-					log.Println("Error sending points to serial device: ", err)
+					log.Println("Error sending points to serial device:", err)
 				}
 			}
 		})
 		if err != nil {
-			log.Println("Error subscribing to serial parent: ", err)
+			log.Println("Error subscribing to serial parent:", err)
 		}
 	} else {
 		sd.natsSubSerialPoints = SubjectNodePoints(sd.config.ID)
@@ -171,7 +171,7 @@ func (sd *SerialDevClient) sendPointsToDevice(seq byte, ack bool, sub string, pt
 
 // Run the main logic for this client and blocks until stopped
 func (sd *SerialDevClient) Run() error {
-	log.Println("Starting serial client: ", sd.config.Description)
+	log.Println("Starting serial client:", sd.config.Description)
 
 	if sd.config.Connected {
 		sd.config.Connected = false
@@ -191,7 +191,7 @@ func (sd *SerialDevClient) Run() error {
 	if sd.config.Port != "" {
 		err := watcher.Add(filepath.Dir(sd.config.Port))
 		if err != nil {
-			log.Println("Error adding watcher for: ", sd.config.Port)
+			log.Println("Error adding watcher for:", sd.config.Port)
 		}
 	}
 
@@ -204,7 +204,7 @@ func (sd *SerialDevClient) Run() error {
 
 	closePort := func() {
 		if sd.portCobsWrapper != nil {
-			log.Println("Closing serial port: ", sd.config.Description)
+			log.Println("Closing serial port:", sd.config.Description)
 			sd.portCobsWrapper.Close()
 		}
 		sd.portCobsWrapper = nil
@@ -258,7 +258,7 @@ func (sd *SerialDevClient) Run() error {
 			err := SendPoints(sd.nc, sd.natsSub,
 				data.Points{{Type: data.PointTypeMaxMessageLength, Value: 1024}}, true)
 			if err != nil {
-				log.Println("Error sending max message len message: ", err)
+				log.Println("Error sending max message len message:", err)
 			}
 		}
 
@@ -280,7 +280,7 @@ func (sd *SerialDevClient) Run() error {
 			var err error
 			io, err = test.NewFifoB(sd.config.Port)
 			if err != nil {
-				log.Println("SerialDevClient: error opening fifo: ", err)
+				log.Println("SerialDevClient: error opening fifo:", err)
 				return
 			}
 		} else {
@@ -329,7 +329,7 @@ func (sd *SerialDevClient) Run() error {
 		sd.portCobsWrapper.SetDebug(sd.config.Debug)
 		timerCheckPort.Stop()
 
-		log.Println("Serial port opened: ", sd.config.Description)
+		log.Println("Serial port opened:", sd.config.Description)
 
 		go listener(sd.portCobsWrapper, sd.config.MaxMessageLength)
 
@@ -369,7 +369,7 @@ exitSerialClient:
 			points := []data.Point{{Type: data.PointTypeErrorCount, Value: float64(sd.config.ErrorCount)}}
 			err := SendPoints(sd.nc, sd.natsSub, points, false)
 			if err != nil {
-				log.Println("Error sending error points: ", err)
+				log.Println("Error sending error points:", err)
 			}
 		case e, ok := <-watcher.Events:
 			if ok {
@@ -383,7 +383,7 @@ exitSerialClient:
 			}
 		case rd := <-serialReadData:
 			if sd.config.Debug >= 8 {
-				log.Println("SER RX RAW: ", test.HexDump(rd))
+				log.Println("SER RX RAW:", test.HexDump(rd))
 			}
 
 			// decode serial packet
@@ -406,7 +406,7 @@ exitSerialClient:
 
 				err := SendPoints(sd.nc, sd.natsSub, []data.Point{{Type: t, Value: float64(cnt)}}, false)
 				if err != nil {
-					log.Println("Error sending error points: ", err)
+					log.Println("Error sending error points:", err)
 				}
 
 				break
@@ -417,7 +417,7 @@ exitSerialClient:
 				sd.config.HrRx++
 				err := sd.nc.Publish(sd.natsSubHRUp, payload)
 				if err != nil {
-					log.Println("Error publishing HR data: ", err)
+					log.Println("Error publishing HR data:", err)
 				}
 				sd.ratePointCountHR++
 				// we're done
@@ -433,7 +433,7 @@ exitSerialClient:
 				}
 				err := SendPoints(sd.nc, sd.natsSubSerialPoints, points, false)
 				if err != nil {
-					log.Println("Error sending log point from MCU: ", err)
+					log.Println("Error sending log point from MCU:", err)
 				}
 			}
 
@@ -460,17 +460,17 @@ exitSerialClient:
 				// send response
 				err := sd.sendPointsToDevice(seq, true, "ack", nil)
 				if err != nil {
-					log.Println("Error sending ack to device: ", err)
+					log.Println("Error sending ack to device:", err)
 				}
 
 				if !sd.config.SyncParent {
 					err = data.MergePoints(sd.config.ID, points, &sd.config)
 					if err != nil {
-						log.Println("error merging new points: ", err)
+						log.Println("error merging new points:", err)
 					}
 				}
 			} else {
-				log.Println("Error decoding serial packet from device: ",
+				log.Println("Error decoding serial packet from device:",
 					sd.config.Description, errDecode)
 				sd.config.ErrorCount++
 				adminPoints = append(adminPoints,
@@ -512,14 +512,14 @@ exitSerialClient:
 			if len(points) > 0 {
 				err := SendPoints(sd.nc, sd.natsSubSerialPoints, points, false)
 				if err != nil {
-					log.Println("Error sending points received from MCU: ", err)
+					log.Println("Error sending points received from MCU:", err)
 				}
 			}
 
 			if len(adminPoints) > 0 {
 				err := SendPoints(sd.nc, sd.natsSub, adminPoints, false)
 				if err != nil {
-					log.Println("Error sending admin points: ", err)
+					log.Println("Error sending admin points:", err)
 				}
 			}
 
@@ -538,7 +538,7 @@ exitSerialClient:
 				if p.Type == data.PointTypePort {
 					err := watcher.Add(filepath.Dir(p.Text))
 					if err != nil {
-						log.Println("Error adding watcher on serial port name change: ", p.Text)
+						log.Println("Error adding watcher on serial port name change:", p.Text)
 					}
 				}
 
@@ -559,7 +559,7 @@ exitSerialClient:
 
 			err := data.MergePoints(pts.ID, pts.Points, &sd.config)
 			if err != nil {
-				log.Println("error merging new points: ", err)
+				log.Println("error merging new points:", err)
 			}
 
 			if updateNatsSubjects {
@@ -581,7 +581,7 @@ exitSerialClient:
 				}
 				err = SendPoints(sd.nc, sd.natsSub, points, false)
 				if err != nil {
-					log.Println("Error resetting MCU error count: ", err)
+					log.Println("Error resetting MCU error count:", err)
 				}
 
 				sd.config.ErrorCountReset = false
@@ -595,7 +595,7 @@ exitSerialClient:
 				}
 				err = SendPoints(sd.nc, sd.natsSub, points, false)
 				if err != nil {
-					log.Println("Error resetting MCU error count: ", err)
+					log.Println("Error resetting MCU error count:", err)
 				}
 
 				sd.config.ErrorCountResetHR = false
@@ -609,7 +609,7 @@ exitSerialClient:
 				}
 				err = SendPoints(sd.nc, sd.natsSub, points, false)
 				if err != nil {
-					log.Println("Error resetting MCU error count: ", err)
+					log.Println("Error resetting MCU error count:", err)
 				}
 
 				sd.config.RxReset = false
@@ -623,7 +623,7 @@ exitSerialClient:
 				}
 				err = SendPoints(sd.nc, sd.natsSub, points, false)
 				if err != nil {
-					log.Println("Error resetting MCU error count: ", err)
+					log.Println("Error resetting MCU error count:", err)
 				}
 
 				sd.config.HrRxReset = false
@@ -637,7 +637,7 @@ exitSerialClient:
 				}
 				err = SendPoints(sd.nc, sd.natsSub, points, false)
 				if err != nil {
-					log.Println("Error resetting MCU error count: ", err)
+					log.Println("Error resetting MCU error count:", err)
 				}
 
 				sd.config.TxReset = false
@@ -670,7 +670,7 @@ exitSerialClient:
 					sd.wrSeq++
 					err := sd.sendPointsToDevice(sd.wrSeq, false, "", toSend)
 					if err != nil {
-						log.Println("Error sending points to serial device: ", err)
+						log.Println("Error sending points to serial device:", err)
 					}
 				}
 			}
@@ -678,19 +678,19 @@ exitSerialClient:
 		case pts := <-sd.newEdgePoints:
 			err := data.MergeEdgePoints(pts.ID, pts.Parent, pts.Points, &sd.config)
 			if err != nil {
-				log.Println("error merging new points: ", err)
+				log.Println("error merging new points:", err)
 			}
 
 			// TODO need to send edge points to MCU, not implemented yet
 		}
 	}
 
-	log.Println("Stopping serial client: ", sd.config.Description)
+	log.Println("Stopping serial client:", sd.config.Description)
 	closePort()
 	if sd.parentSubscription != nil {
 		err := sd.parentSubscription.Unsubscribe()
 		if err != nil {
-			log.Println("Error unsubscribing: ", err)
+			log.Println("Error unsubscribing:", err)
 		}
 	}
 

--- a/client/shelly-io-client.go
+++ b/client/shelly-io-client.go
@@ -28,7 +28,7 @@ func NewShellyIOClient(nc *nats.Conn, config ShellyIo) Client {
 	// we need a copy of points with timestamps so we know when to send up new data
 	ne, err := data.Encode(config)
 	if err != nil {
-		log.Println("Error encoding shelly config: ", err)
+		log.Println("Error encoding shelly config:", err)
 	}
 
 	return &ShellyIOClient{
@@ -45,7 +45,7 @@ func NewShellyIOClient(nc *nats.Conn, config ShellyIo) Client {
 
 // Run runs the main logic for this client and blocks until stopped
 func (sioc *ShellyIOClient) Run() error {
-	log.Println("Starting shelly IO client: ", sioc.config.Description)
+	log.Println("Starting shelly IO client:", sioc.config.Description)
 
 	sampleRate := time.Second * 2
 	sampleRateOffline := time.Minute * 10
@@ -70,7 +70,7 @@ func (sioc *ShellyIOClient) Run() error {
 				Type: data.PointTypeOffline, Value: 1}, false)
 
 			if err != nil {
-				log.Println("ShellyIO: error sending node point: ", err)
+				log.Println("ShellyIO: error sending node point:", err)
 			}
 			sampleTicker = time.NewTicker(sampleRateOffline)
 		}
@@ -85,7 +85,7 @@ func (sioc *ShellyIOClient) Run() error {
 				Type: data.PointTypeOffline, Value: 0}, false)
 
 			if err != nil {
-				log.Println("ShellyIO: error sending node point: ", err)
+				log.Println("ShellyIO: error sending node point:", err)
 			}
 			sampleTicker = time.NewTicker(sampleRate)
 		}
@@ -95,7 +95,7 @@ func (sioc *ShellyIOClient) Run() error {
 		config, err := sioc.config.getConfig()
 		if err != nil {
 			shellyError()
-			log.Println("Error getting shelly IO settings: ", sioc.config.Desc(), err)
+			log.Println("Error getting shelly IO settings:", sioc.config.Desc(), err)
 			return
 		}
 
@@ -106,12 +106,12 @@ func (sioc *ShellyIOClient) Run() error {
 			err := SendNodePoint(sioc.nc, sioc.config.ID, data.Point{
 				Type: data.PointTypeDescription, Text: config.Name}, false)
 			if err != nil {
-				log.Println("Error sending shelly io description: ", err)
+				log.Println("Error sending shelly io description:", err)
 			}
 		} else if sioc.config.Description != config.Name {
 			err := sioc.config.SetName(sioc.config.Description)
 			if err != nil {
-				log.Println("Error setting name on Shelly device: ", err)
+				log.Println("Error setting name on Shelly device:", err)
 			}
 		}
 	}
@@ -122,12 +122,12 @@ done:
 	for {
 		select {
 		case <-sioc.stop:
-			log.Println("Stopping shelly IO client: ", sioc.config.Description)
+			log.Println("Stopping shelly IO client:", sioc.config.Description)
 			break done
 		case pts := <-sioc.newPoints:
 			err := data.MergePoints(pts.ID, pts.Points, &sioc.config)
 			if err != nil {
-				log.Println("error merging new points: ", err)
+				log.Println("error merging new points:", err)
 			}
 
 			for _, p := range pts.Points {
@@ -154,7 +154,7 @@ done:
 		case pts := <-sioc.newEdgePoints:
 			err := data.MergeEdgePoints(pts.ID, pts.Parent, pts.Points, &sioc.config)
 			if err != nil {
-				log.Println("error merging new points: ", err)
+				log.Println("error merging new points:", err)
 			}
 
 		case <-syncConfigTicker.C:
@@ -225,11 +225,11 @@ done:
 			if len(newPoints) > 0 {
 				err := data.MergePoints(sioc.config.ID, newPoints, &sioc.config)
 				if err != nil {
-					log.Println("shelly io: error merging newPoints: ", err)
+					log.Println("shelly io: error merging newPoints:", err)
 				}
 				err = SendNodePoints(sioc.nc, sioc.config.ID, newPoints, false)
 				if err != nil {
-					log.Println("shelly io: error sending newPoints: ", err)
+					log.Println("shelly io: error sending newPoints:", err)
 				}
 			}
 		}

--- a/client/shelly.go
+++ b/client/shelly.go
@@ -45,7 +45,7 @@ func NewShellyClient(nc *nats.Conn, config Shelly) Client {
 
 // Run runs the main logic for this client and blocks until stopped
 func (sc *ShellyClient) Run() error {
-	log.Println("Starting shelly client: ", sc.config.Description)
+	log.Println("Starting shelly client:", sc.config.Description)
 
 	entriesCh := make(chan *mdns.ServiceEntry, 4)
 
@@ -56,7 +56,7 @@ func (sc *ShellyClient) Run() error {
 	scan := func() {
 		err := mdns.Query(params)
 		if err != nil {
-			log.Println("mdns error: ", err)
+			log.Println("mdns error:", err)
 		}
 	}
 
@@ -68,12 +68,12 @@ done:
 	for {
 		select {
 		case <-sc.stop:
-			log.Println("Stopping shelly client: ", sc.config.Description)
+			log.Println("Stopping shelly client:", sc.config.Description)
 			break done
 		case pts := <-sc.newPoints:
 			err := data.MergePoints(pts.ID, pts.Points, &sc.config)
 			if err != nil {
-				log.Println("error merging new points: ", err)
+				log.Println("error merging new points:", err)
 			}
 
 			for _, p := range pts.Points {
@@ -85,7 +85,7 @@ done:
 		case pts := <-sc.newEdgePoints:
 			err := data.MergeEdgePoints(pts.ID, pts.Parent, pts.Points, &sc.config)
 			if err != nil {
-				log.Println("error merging new points: ", err)
+				log.Println("error merging new points:", err)
 			}
 
 		case <-scanTicker.C:
@@ -118,7 +118,7 @@ done:
 							}, false)
 
 							if err != nil {
-								log.Println("Error setting io ip: ", err)
+								log.Println("Error setting io ip:", err)
 							}
 						}
 
@@ -130,7 +130,7 @@ done:
 							}, false)
 
 							if err != nil {
-								log.Println("Error setting io offline: ", err)
+								log.Println("Error setting io offline:", err)
 							} else {
 								sc.config.IOs[i].Offline = false
 							}
@@ -152,7 +152,7 @@ done:
 
 				ne, err := data.Encode(newIO)
 				if err != nil {
-					log.Println("Error encoding new shelly IO: ", err)
+					log.Println("Error encoding new shelly IO:", err)
 					continue
 				}
 
@@ -178,7 +178,7 @@ done:
 
 				err = SendNode(sc.nc, ne, sc.config.ID)
 				if err != nil {
-					log.Println("Error sending shelly IO: ", err)
+					log.Println("Error sending shelly IO:", err)
 				}
 			}
 		}

--- a/client/sync.go
+++ b/client/sync.go
@@ -102,7 +102,7 @@ func (up *SyncClient) Run() error {
 		nodeID, points, err := DecodeNodePointsMsg(msg)
 
 		if err != nil {
-			log.Println("Error decoding point: ", err)
+			log.Println("Error decoding point:", err)
 			return
 		}
 
@@ -110,14 +110,14 @@ func (up *SyncClient) Run() error {
 
 	})
 	if err != nil {
-		log.Println("SyncClient: error subscribing: ", err)
+		log.Println("SyncClient: error subscribing:", err)
 	}
 
 	subLocalEdgePoints, err := up.ncLocal.Subscribe(SubjectEdgeAllPoints(), func(msg *nats.Msg) {
 		nodeID, parentID, points, err := DecodeEdgePointsMsg(msg)
 
 		if err != nil {
-			log.Println("Error decoding point: ", err)
+			log.Println("Error decoding point:", err)
 			return
 		}
 
@@ -131,7 +131,7 @@ func (up *SyncClient) Run() error {
 		}
 	})
 	if err != nil {
-		log.Println("SyncClient: error subscribing: ", err)
+		log.Println("SyncClient: error subscribing:", err)
 	}
 
 	checkPeriod := func() {
@@ -143,7 +143,7 @@ func (up *SyncClient) Run() error {
 
 			err = SendPoints(up.nc, SubjectNodePoints(up.config.ID), points, false)
 			if err != nil {
-				log.Println("Error resetting sync sync count: ", err)
+				log.Println("Error resetting sync sync count:", err)
 			}
 		}
 	}
@@ -167,7 +167,7 @@ done:
 	for {
 		select {
 		case <-up.stop:
-			log.Println("Stopping upstream client: ", up.config.Description)
+			log.Println("Stopping upstream client:", up.config.Description)
 			break done
 		case <-connectTimer.C:
 			err := up.connect()
@@ -179,7 +179,7 @@ done:
 		case <-syncTicker.C:
 			err := up.syncNode("root", up.rootLocal.ID)
 			if err != nil {
-				log.Println("Error syncing: ", err)
+				log.Println("Error syncing:", err)
 			}
 
 		case conn := <-up.chConnected:
@@ -188,14 +188,14 @@ done:
 				syncTicker.Reset(time.Duration(up.config.Period) * time.Second)
 				err := up.syncNode("root", up.rootLocal.ID)
 				if err != nil {
-					log.Println("Error syncing: ", err)
+					log.Println("Error syncing:", err)
 				}
 
 				if !up.initialSub {
 					// set up initial subscriptions to remote nodes
 					err = up.subscribeRemoteNode(up.rootLocal.Parent, up.rootLocal.ID)
 					if err != nil {
-						log.Println("Sync: initial sub failed: ", err)
+						log.Println("Sync: initial sub failed:", err)
 					} else {
 						up.initialSub = true
 					}
@@ -210,20 +210,20 @@ done:
 			if connected {
 				err = SendNodePoints(up.ncRemote, pts.ID, pts.Points, false)
 				if err != nil {
-					log.Println("Error sending node points to remote system: ", err)
+					log.Println("Error sending node points to remote system:", err)
 				}
 			}
 		case pts := <-chLocalEdgePoints:
 			if connected {
 				err = SendEdgePoints(up.ncRemote, pts.ID, pts.Parent, pts.Points, false)
 				if err != nil {
-					log.Println("Error sending edge points to remote system: ", err)
+					log.Println("Error sending edge points to remote system:", err)
 				}
 			}
 		case pts := <-up.newPoints:
 			err := data.MergePoints(pts.ID, pts.Points, &up.config)
 			if err != nil {
-				log.Println("error merging new points: ", err)
+				log.Println("error merging new points:", err)
 			}
 
 			for _, p := range pts.Points {
@@ -254,14 +254,14 @@ done:
 
 				err = SendPoints(up.nc, SubjectNodePoints(up.config.ID), points, false)
 				if err != nil {
-					log.Println("Error resetting sync sync count: ", err)
+					log.Println("Error resetting sync sync count:", err)
 				}
 			}
 
 		case pts := <-up.newEdgePoints:
 			err := data.MergeEdgePoints(pts.ID, pts.Parent, pts.Points, &up.config)
 			if err != nil {
-				log.Println("error merging new points: ", err)
+				log.Println("error merging new points:", err)
 			}
 		case edge := <-up.chNewEdge:
 			if !edge.local {
@@ -275,7 +275,7 @@ done:
 
 				nodes, err := GetNodes(up.ncLocal, edge.parent, edge.id, "", true)
 				if err != nil {
-					log.Println("Error getting local node: ", err)
+					log.Println("Error getting local node:", err)
 					break
 				}
 
@@ -290,7 +290,7 @@ done:
 				time.Sleep(10 * time.Millisecond)
 				nodes, err = GetNodes(up.ncRemote, edge.parent, edge.id, "", true)
 				if err != nil {
-					log.Println("Error getting node: ", err)
+					log.Println("Error getting node:", err)
 					break
 				}
 				for _, n := range nodes {
@@ -300,14 +300,14 @@ done:
 					}
 					err := up.sendNodesLocal(n)
 					if err != nil {
-						log.Println("Error chNewEdge sendNodesLocal: ", err)
+						log.Println("Error chNewEdge sendNodesLocal:", err)
 					}
 				}
 			}
 
 			err = up.subscribeRemoteNode(edge.parent, edge.id)
 			if err != nil {
-				log.Println("Error subscribing to new edge: ", err)
+				log.Println("Error subscribing to new edge:", err)
 			}
 		}
 	}
@@ -315,12 +315,12 @@ done:
 	// clean up
 	err = subLocalNodePoints.Unsubscribe()
 	if err != nil {
-		log.Println("Error unsubscribing node points from local bus: ", err)
+		log.Println("Error unsubscribing node points from local bus:", err)
 	}
 
 	err = subLocalEdgePoints.Unsubscribe()
 	if err != nil {
-		log.Println("Error unsubscribing edge points from local bus: ", err)
+		log.Println("Error unsubscribing edge points from local bus:", err)
 	}
 
 	up.disconnect()
@@ -390,13 +390,13 @@ func (up *SyncClient) subscribeRemoteNodePoints(id string) error {
 		up.subRemoteNodePoints[id], err = up.ncRemote.Subscribe(SubjectNodePoints(id), func(msg *nats.Msg) {
 			nodeID, points, err := DecodeNodePointsMsg(msg)
 			if err != nil {
-				log.Println("Error decoding point: ", err)
+				log.Println("Error decoding point:", err)
 				return
 			}
 
 			err = SendNodePoints(up.ncLocal, nodeID, points, false)
 			if err != nil {
-				log.Println("Error sending node points to remote system: ", err)
+				log.Println("Error sending node points to remote system:", err)
 			}
 		})
 
@@ -416,13 +416,13 @@ func (up *SyncClient) subscribeRemoteEdgePoints(parent, id string) error {
 			func(msg *nats.Msg) {
 				nodeID, parentID, points, err := DecodeEdgePointsMsg(msg)
 				if err != nil {
-					log.Println("Error decoding point: ", err)
+					log.Println("Error decoding point:", err)
 					return
 				}
 
 				err = SendEdgePoints(up.ncLocal, nodeID, parentID, points, false)
 				if err != nil {
-					log.Println("Error sending edge points to remote system: ", err)
+					log.Println("Error sending edge points to remote system:", err)
 				}
 			})
 
@@ -464,7 +464,7 @@ func (up *SyncClient) disconnect() {
 	for key, sub := range up.subRemoteNodePoints {
 		err := sub.Unsubscribe()
 		if err != nil {
-			log.Println("Error unsubscribing from remote: ", err)
+			log.Println("Error unsubscribing from remote:", err)
 		}
 		delete(up.subRemoteNodePoints, key)
 	}
@@ -472,7 +472,7 @@ func (up *SyncClient) disconnect() {
 	for key, sub := range up.subRemoteEdgePoints {
 		err := sub.Unsubscribe()
 		if err != nil {
-			log.Println("Error unsubscribing from remote: ", err)
+			log.Println("Error unsubscribing from remote:", err)
 		}
 		delete(up.subRemoteEdgePoints, key)
 	}
@@ -481,7 +481,7 @@ func (up *SyncClient) disconnect() {
 	if up.subRemoteUp != nil {
 		err := up.subRemoteUp.Unsubscribe()
 		if err != nil {
-			log.Println("subRemoteUp.Unsubscribe() error: ", err)
+			log.Println("subRemoteUp.Unsubscribe() error:", err)
 		}
 		up.subRemoteUp = nil
 	}
@@ -564,7 +564,7 @@ func (up *SyncClient) syncNode(parent, id string) error {
 		up.subRemoteUp, err = up.ncRemote.Subscribe(subject, func(msg *nats.Msg) {
 			_, id, parent, points, err := DecodeUpEdgePointsMsg(msg)
 			if err != nil {
-				log.Println("Error decoding remote up points: ", err)
+				log.Println("Error decoding remote up points:", err)
 			} else {
 				for _, p := range points {
 					if p.Type == data.PointTypeTombstone &&
@@ -578,7 +578,7 @@ func (up *SyncClient) syncNode(parent, id string) error {
 		})
 
 		if err != nil {
-			log.Println("Error subscribing to remote up...: ", err)
+			log.Println("Error subscribing to remote up...:", err)
 		}
 	}
 
@@ -678,7 +678,7 @@ func (up *SyncClient) syncNode(parent, id string) error {
 
 		err = SendPoints(up.nc, SubjectNodePoints(up.config.ID), points, false)
 		if err != nil {
-			log.Println("Error resetting sync sync count: ", err)
+			log.Println("Error resetting sync sync count:", err)
 		}
 	}
 
@@ -701,13 +701,13 @@ func (up *SyncClient) syncNode(parent, id string) error {
 					// need to send point upstream
 					err := SendNodePoint(up.ncRemote, nodeUp.ID, p, true)
 					if err != nil {
-						log.Println("Error syncing point upstream: ", err)
+						log.Println("Error syncing point upstream:", err)
 					}
 				} else if p.Time.Before(pUp.Time) {
 					// need to update point locally
 					err := SendNodePoint(up.nc, nodeLocal.ID, pUp, true)
 					if err != nil {
-						log.Println("Error syncing point from upstream: ", err)
+						log.Println("Error syncing point from upstream:", err)
 					}
 				}
 			}
@@ -716,7 +716,7 @@ func (up *SyncClient) syncNode(parent, id string) error {
 		if !found {
 			err := SendNodePoint(up.ncRemote, nodeUp.ID, p, true)
 			if err != nil {
-				log.Println("Error sending point: ", err)
+				log.Println("Error sending point:", err)
 			}
 		}
 	}
@@ -726,7 +726,7 @@ func (up *SyncClient) syncNode(parent, id string) error {
 		if _, ok := upstreamProcessed[i]; !ok {
 			err := SendNodePoint(up.nc, nodeLocal.ID, pUp, true)
 			if err != nil {
-				log.Println("Error syncing point from upstream: ", err)
+				log.Println("Error syncing point from upstream:", err)
 			}
 		}
 	}
@@ -747,13 +747,13 @@ func (up *SyncClient) syncNode(parent, id string) error {
 						// need to send point upstream
 						err := SendEdgePoint(up.ncRemote, nodeUp.ID, nodeUp.Parent, p, true)
 						if err != nil {
-							log.Println("Error syncing point upstream: ", err)
+							log.Println("Error syncing point upstream:", err)
 						}
 					} else if p.Time.Before(pUp.Time) {
 						// need to update point locally
 						err := SendEdgePoint(up.nc, nodeLocal.ID, nodeLocal.Parent, pUp, true)
 						if err != nil {
-							log.Println("Error syncing point from upstream: ", err)
+							log.Println("Error syncing point from upstream:", err)
 						}
 					}
 				}
@@ -762,7 +762,7 @@ func (up *SyncClient) syncNode(parent, id string) error {
 			if !found {
 				err := SendEdgePoint(up.ncRemote, nodeUp.ID, nodeUp.Parent, p, true)
 				if err != nil {
-					log.Println("Error sending point: ", err)
+					log.Println("Error sending point:", err)
 				}
 			}
 		}
@@ -772,7 +772,7 @@ func (up *SyncClient) syncNode(parent, id string) error {
 			if _, ok := upstreamProcessed[i]; !ok {
 				err := SendEdgePoint(up.nc, nodeLocal.ID, nodeLocal.Parent, pUp, true)
 				if err != nil {
-					log.Println("Error syncing edge point from upstream: ", err)
+					log.Println("Error syncing edge point from upstream:", err)
 				}
 			}
 		}
@@ -812,12 +812,12 @@ func (up *SyncClient) syncNode(parent, id string) error {
 			// need to send node upstream
 			err := up.sendNodesRemote(child)
 			if err != nil {
-				log.Println("Error sending node upstream: ", err)
+				log.Println("Error sending node upstream:", err)
 			}
 
 			err = up.subscribeRemoteNode(child.Parent, child.ID)
 			if err != nil {
-				log.Println("Error subscribing to upstream: ", err)
+				log.Println("Error subscribing to upstream:", err)
 			}
 		}
 	}
@@ -826,11 +826,11 @@ func (up *SyncClient) syncNode(parent, id string) error {
 		if _, ok := upChildProcessed[i]; !ok {
 			err := up.sendNodesLocal(upChild)
 			if err != nil {
-				log.Println("Error getting node from upstream: ", err)
+				log.Println("Error getting node from upstream:", err)
 			}
 			err = up.subscribeRemoteNode(upChild.Parent, upChild.ID)
 			if err != nil {
-				log.Println("Error subscribing to upstream: ", err)
+				log.Println("Error subscribing to upstream:", err)
 			}
 		}
 	}

--- a/client/update.go
+++ b/client/update.go
@@ -29,7 +29,7 @@ func StartUpdate(id, url string) error {
 			})
 
 			if err != nil {
-				log.Println("Error setting update status in DB: ", err)
+				log.Println("Error setting update status in DB:", err)
 			}
 		})
 
@@ -50,7 +50,7 @@ func StartUpdate(id, url string) error {
 
 		err = st.setSwUpdateState(id, state)
 		if err != nil {
-			log.Println("Error setting sw update state: ", err)
+			log.Println("Error setting sw update state:", err)
 		}
 	}()
 

--- a/cmd/edge/main.go
+++ b/cmd/edge/main.go
@@ -36,12 +36,12 @@ func main() {
 	nc, err := client.EdgeConnect(opts)
 
 	if err != nil {
-		log.Println("Error connecting to NATS server: ", err)
+		log.Println("Error connecting to NATS server:", err)
 		os.Exit(-1)
 	}
 
 	_ = client.ListenForFile(nc, "./", *flagID, func(name string) {
-		log.Println("File downloaded: ", name)
+		log.Println("File downloaded:", name)
 	})
 
 	select {}

--- a/cmd/fetch/main.go
+++ b/cmd/fetch/main.go
@@ -23,7 +23,7 @@ func httpDownload(url, fn string) {
 
 	file, err := os.Create(fn)
 	if err != nil {
-		log.Println("App update: error creating file: ", err)
+		log.Println("App update: error creating file:", err)
 		return
 	}
 
@@ -36,7 +36,7 @@ func httpDownload(url, fn string) {
 	// Get the data
 	resp, err := netClient.Get(url)
 	if err != nil {
-		log.Println("App update: error getting update file: ", err)
+		log.Println("App update: error getting update file:", err)
 		return
 	}
 	defer resp.Body.Close()
@@ -45,7 +45,7 @@ func httpDownload(url, fn string) {
 	_, err = io.Copy(file, resp.Body)
 
 	if err != nil {
-		log.Println("App update: error downloading update file: ", err)
+		log.Println("App update: error downloading update file:", err)
 		return
 	}
 
@@ -56,7 +56,7 @@ func httpDownload(url, fn string) {
 func grabDownload(url, fn string) {
 	file, err := os.Create(fn)
 	if err != nil {
-		log.Println("App update: error creating file: ", err)
+		log.Println("App update: error creating file:", err)
 		return
 	}
 
@@ -79,7 +79,7 @@ func grabDownload(url, fn string) {
 
 		case <-resp.Done:
 			if err := resp.Err(); err != nil {
-				log.Println("Error downloading: ", err)
+				log.Println("Error downloading:", err)
 			}
 			return
 		}
@@ -112,7 +112,7 @@ func main() {
 	url, err := url.Parse(*flagURL)
 
 	if err != nil {
-		log.Println("Error parsing url: ", err)
+		log.Println("Error parsing url:", err)
 		os.Exit(-1)
 	}
 

--- a/cmd/modbus-client/main.go
+++ b/cmd/modbus-client/main.go
@@ -34,7 +34,7 @@ func main() {
 	baud, err := strconv.Atoi(*flagBaud)
 
 	if err != nil {
-		log.Println("Baud rate error: ", err)
+		log.Println("Baud rate error:", err)
 		os.Exit(-1)
 	}
 
@@ -58,7 +58,7 @@ func main() {
 		os.Exit(-1)
 	}
 
-	log.Println("Coil results: ", coils)
+	log.Println("Coil results:", coils)
 
 	// read holding reg
 	regs, _ := client.ReadHoldingRegs(1, 2, 1)

--- a/cmd/modbus-server/main.go
+++ b/cmd/modbus-server/main.go
@@ -35,7 +35,7 @@ func main() {
 	baud, err := strconv.Atoi(*flagBaud)
 
 	if err != nil {
-		log.Println("Baud rate error: ", err)
+		log.Println("Baud rate error:", err)
 		os.Exit(-1)
 	}
 
@@ -58,20 +58,20 @@ func main() {
 	regs.AddCoil(128)
 	err = regs.WriteCoil(128, true)
 	if err != nil {
-		log.Println("Error writing coil: ", err)
+		log.Println("Error writing coil:", err)
 		os.Exit(-1)
 	}
 
 	regs.AddReg(2, 1)
 	err = regs.WriteReg(2, 5)
 	if err != nil {
-		log.Println("Error writing reg: ", err)
+		log.Println("Error writing reg:", err)
 		os.Exit(-1)
 	}
 
 	// start slave so it can respond to requests
 	go serv.Listen(func(err error) {
-		log.Println("modbus server listen error: ", err)
+		log.Println("modbus server listen error:", err)
 	}, func() {
 		log.Printf("modbus reg changes")
 	}, func() {
@@ -79,7 +79,7 @@ func main() {
 	})
 
 	if err != nil {
-		log.Println("Error opening modbus port: ", err)
+		log.Println("Error opening modbus port:", err)
 	}
 
 	value := true

--- a/cmd/modbus/main.go
+++ b/cmd/modbus/main.go
@@ -47,7 +47,7 @@ func main() {
 	baud, err := strconv.Atoi(*flagBaud)
 
 	if err != nil {
-		log.Println("Baud rate error: ", err)
+		log.Println("Baud rate error:", err)
 		os.Exit(-1)
 	}
 
@@ -77,7 +77,7 @@ func main() {
 			uint16(*flagCount))
 
 		if err != nil {
-			log.Println("Error reading holding regs: ", err)
+			log.Println("Error reading holding regs:", err)
 			os.Exit(-1)
 		}
 

--- a/cmd/send-sms/main.go
+++ b/cmd/send-sms/main.go
@@ -32,7 +32,7 @@ func main() {
 	err := twilio.SendSMS(*flagTo, *flagMsg)
 
 	if err != nil {
-		log.Println("Error sending message: ", err)
+		log.Println("Error sending message:", err)
 		os.Exit(-1)
 	}
 

--- a/cmd/siot/main.go
+++ b/cmd/siot/main.go
@@ -69,7 +69,7 @@ func main() {
 	switch args[0] {
 	case "serve":
 		if err := runServer(args[1:], version, *flagID); err != nil {
-			log.Println("Simple IoT stopped, reason: ", err)
+			log.Println("Simple IoT stopped, reason:", err)
 		}
 	case "log":
 		runLog(args[1:])
@@ -229,7 +229,7 @@ func runStore(args []string) {
 	nc, err := client.EdgeConnect(opts)
 
 	if err != nil {
-		log.Println("Error connecting to NATS server: ", err)
+		log.Println("Error connecting to NATS server:", err)
 		os.Exit(-1)
 	}
 
@@ -237,7 +237,7 @@ func runStore(args []string) {
 	case *flagCheck:
 		err := client.AdminStoreVerify(nc)
 		if err != nil {
-			log.Println("DB verify failed: ", err)
+			log.Println("DB verify failed:", err)
 		} else {
 			log.Println("DB verified :-)")
 		}
@@ -245,7 +245,7 @@ func runStore(args []string) {
 	case *flagFix:
 		err := client.AdminStoreMaint(nc)
 		if err != nil {
-			log.Println("DB maint failed: ", err)
+			log.Println("DB maint failed:", err)
 		} else {
 			log.Println("DB maint success :-)")
 		}
@@ -313,9 +313,9 @@ func runInstall(args []string) {
 		log.Fatal("Error getting SIOT path: ", err)
 	}
 
-	log.Println("Installing service file: ", servicePath)
-	log.Println("SIOT executable location: ", siotPath)
-	log.Println("SIOT data location: ", dataDir)
+	log.Println("Installing service file:", servicePath)
+	log.Println("SIOT executable location:", siotPath)
+	log.Println("SIOT data location:", dataDir)
 
 	_, err = os.Stat(servicePath)
 

--- a/cmd/tof10120/main.go
+++ b/cmd/tof10120/main.go
@@ -46,16 +46,16 @@ func main() {
 	err = tof.SetSendInterval(*flagSend)
 
 	if err != nil {
-		log.Println("Error setting send interval: ", err)
+		log.Println("Error setting send interval:", err)
 	}
 
 	err = tof.Read(func(v int) {
 		log.Printf("TOF data: %vmm\n", v)
 	}, func(err error) {
-		log.Println("Error reading TOF: ", err)
+		log.Println("Error reading TOF:", err)
 	})
 
 	if err != nil {
-		log.Println("Error reading TOF: ", err)
+		log.Println("Error reading TOF:", err)
 	}
 }

--- a/docs/user/can.md
+++ b/docs/user/can.md
@@ -140,13 +140,13 @@ func (tnc *exNodeClient) Run() error {
 		case pts := <-tnc.newPoints:
 			err := data.MergePoints(pts.ID, pts.Points, &tnc.config)
 			if err != nil {
-				log.Println("error merging new points: ", err)
+				log.Println("error merging new points:", err)
 			}
 			log.Printf("New config: %+v\n", tnc.config)
 		case pts := <-tnc.newEdgePoints:
 			err := data.MergeEdgePoints(pts.ID, pts.Parent, pts.Points, &tnc.config)
 			if err != nil {
-				log.Println("error merging new points: ", err)
+				log.Println("error merging new points:", err)
 			}
 		case ch := <-tnc.chGetConfig:
 			ch <- tnc.config
@@ -175,7 +175,7 @@ func main() {
 	nc, root, stop, err := server.TestServer()
 
 	if err != nil {
-		log.Println("Error starting test server: ", err)
+		log.Println("Error starting test server:", err)
 	}
 
 	defer stop()
@@ -189,7 +189,7 @@ func main() {
 
 	err = client.SendNodeType(nc, canBusTest, "test")
 	if err != nil {
-		log.Println("Error sending CAN node: ", err)
+		log.Println("Error sending CAN node:", err)
 	}
 
 	// Create a new manager for nodes of type "testNode". The manager looks for new nodes under the

--- a/modbus/rtu-end-to-end_test.go
+++ b/modbus/rtu-end-to-end_test.go
@@ -37,7 +37,7 @@ func TestRtuEndToEnd(t *testing.T) {
 
 	// start slave so it can respond to requests
 	go slave.Listen(func(err error) {
-		log.Println("modbus server listen error: ", err)
+		log.Println("modbus server listen error:", err)
 	}, func() {
 		log.Printf("modbus reg changes")
 	}, func() {

--- a/modbus/server.go
+++ b/modbus/server.go
@@ -64,7 +64,7 @@ func (s *Server) Listen(errorCallback func(error),
 			if err != io.EOF && s.transport.Type() == TransportTypeRTU {
 				// only print errors for RTU for now as we get timeout
 				// errors with TCP
-				log.Println("Error reading modbus port: ", err)
+				log.Println("Error reading modbus port:", err)
 			}
 
 			if err == io.EOF && s.transport.Type() == TransportTypeTCP {

--- a/modbus/tcp.go
+++ b/modbus/tcp.go
@@ -164,7 +164,7 @@ func (ts *TCPServer) Listen(errorCallback func(error),
 				done()
 				return
 			}
-			log.Println("Modbus TCP server: failed to accept connection: ", err)
+			log.Println("Modbus TCP server: failed to accept connection:", err)
 		}
 
 		if ts.debug > 0 {

--- a/network/at-commands.go
+++ b/network/at-commands.go
@@ -41,7 +41,7 @@ func Cmd(port io.ReadWriter, cmd string) (string, error) {
 
 	for try := 0; try < 3; try++ {
 		if DebugAtCommands {
-			log.Println("Modem Tx: ", cmd)
+			log.Println("Modem Tx:", cmd)
 		}
 
 		readString := make([]byte, 512)
@@ -49,7 +49,7 @@ func Cmd(port io.ReadWriter, cmd string) (string, error) {
 		_, err = port.Write([]byte(cmd + "\r"))
 		if err != nil {
 			if DebugAtCommands {
-				log.Println("Modem cmd write error: ", err)
+				log.Println("Modem cmd write error:", err)
 			}
 			continue
 		}
@@ -59,7 +59,7 @@ func Cmd(port io.ReadWriter, cmd string) (string, error) {
 
 		if err != nil {
 			if DebugAtCommands {
-				log.Println("Modem cmd read error: ", err)
+				log.Println("Modem cmd read error:", err)
 			}
 			continue
 		}
@@ -69,7 +69,7 @@ func Cmd(port io.ReadWriter, cmd string) (string, error) {
 		readStringS := strings.TrimSpace(string(readString))
 
 		if DebugAtCommands {
-			log.Println("Modem Rx: ", readStringS)
+			log.Println("Modem Rx:", readStringS)
 		}
 
 		return readStringS, nil

--- a/network/manager.go
+++ b/network/manager.go
@@ -98,7 +98,7 @@ func (m *Manager) nextInterface() {
 
 	m.setState(StateNotDetected)
 
-	log.Println("Network: trying next interface: ", m.Desc())
+	log.Println("Network: trying next interface:", m.Desc())
 }
 
 func (m *Manager) connect() error {
@@ -122,7 +122,7 @@ func (m *Manager) Reset() {
 	for _, i := range m.interfaces {
 		err := i.Reset()
 		if err != nil {
-			log.Println("Error resetting interface: ", err)
+			log.Println("Error resetting interface:", err)
 		}
 	}
 }
@@ -141,7 +141,7 @@ func (m *Manager) Run() (State, InterfaceConfig, InterfaceStatus) {
 		if count > 10 {
 			log.Println("network state machine ran too many times")
 			if time.Since(m.stateStart) > time.Second*15 {
-				log.Println("Network: timeout: ", m.Desc())
+				log.Println("Network: timeout:", m.Desc())
 				m.nextInterface()
 			}
 
@@ -152,7 +152,7 @@ func (m *Manager) Run() (State, InterfaceConfig, InterfaceStatus) {
 			var err error
 			status, err = m.getStatus()
 			if err != nil {
-				log.Println("Error getting interface status: ", err)
+				log.Println("Error getting interface status:", err)
 				continue
 			}
 		}
@@ -166,7 +166,7 @@ func (m *Manager) Run() (State, InterfaceConfig, InterfaceStatus) {
 				m.setState(StateConfigure)
 				continue
 			} else if time.Since(m.stateStart) > time.Second*15 {
-				log.Println("Network: timeout detecting: ", m.Desc())
+				log.Println("Network: timeout detecting:", m.Desc())
 				m.nextInterface()
 				continue
 			}
@@ -192,7 +192,7 @@ func (m *Manager) Run() (State, InterfaceConfig, InterfaceStatus) {
 			if try < 3 {
 				m.setState(StateConnecting)
 			} else {
-				log.Println("giving up configuring device: ", m.Desc())
+				log.Println("giving up configuring device:", m.Desc())
 				m.nextInterface()
 			}
 
@@ -202,7 +202,7 @@ func (m *Manager) Run() (State, InterfaceConfig, InterfaceStatus) {
 				m.setState(StateConnected)
 			} else {
 				if time.Since(m.stateStart) > time.Minute {
-					log.Println("Network: timeout connecting: ", m.Desc())
+					log.Println("Network: timeout connecting:", m.Desc())
 					m.nextInterface()
 					continue
 				}
@@ -210,7 +210,7 @@ func (m *Manager) Run() (State, InterfaceConfig, InterfaceStatus) {
 				// try again to connect
 				err := m.connect()
 				if err != nil {
-					log.Println("Error connecting: ", err)
+					log.Println("Error connecting:", err)
 				}
 			}
 

--- a/network/modem.go
+++ b/network/modem.go
@@ -237,7 +237,7 @@ func (m *Modem) Connect() error {
 		return err
 	}
 
-	log.Println("BG96 scan mode: ", mode)
+	log.Println("BG96 scan mode:", mode)
 
 	if mode != BG96ScanModeLTE {
 		log.Println("Setting BG96 scan mode")
@@ -318,7 +318,7 @@ func (m *Modem) Reset() error {
 
 	err := exec.Command("poff").Run()
 	if err != nil {
-		log.Println("poff exec error: ", err)
+		log.Println("poff exec error:", err)
 	}
 	if m.enabled {
 		err := m.config.Reset()
@@ -332,7 +332,7 @@ func (m *Modem) Reset() error {
 
 // Enable or disable interface
 func (m *Modem) Enable(en bool) error {
-	log.Println("Modem enable: ", en)
+	log.Println("Modem enable:", en)
 	var err error
 	m.enabled = en
 	if err = m.openCmdPort(); err != nil {

--- a/node/modbus-io.go
+++ b/node/modbus-io.go
@@ -26,7 +26,7 @@ func NewModbusIO(nc *nats.Conn, node *ModbusIONode, chPoint chan<- pointWID) (*M
 		points, err := data.PbDecodePoints(msg.Data)
 		if err != nil {
 			// FIXME, send over channel
-			log.Println("Error decoding node data: ", err)
+			log.Println("Error decoding node data:", err)
 			return
 		}
 
@@ -47,7 +47,7 @@ func (io *ModbusIO) Stop() {
 	if io.sub != nil {
 		err := io.sub.Unsubscribe()
 		if err != nil {
-			log.Println("Error unsubscribing from IO: ", err)
+			log.Println("Error unsubscribing from IO:", err)
 		}
 	}
 }

--- a/node/modbus-manager.go
+++ b/node/modbus-manager.go
@@ -41,7 +41,7 @@ func (mm *ModbusManager) Update() error {
 			var err error
 			bus, err := NewModbus(mm.nc, node)
 			if err != nil {
-				log.Println("Error creating new modbus: ", err)
+				log.Println("Error creating new modbus:", err)
 				continue
 			}
 			mm.busses[node.ID] = bus
@@ -53,7 +53,7 @@ func (mm *ModbusManager) Update() error {
 		_, ok := found[id]
 		if !ok {
 			// bus was deleted so close and clear it
-			log.Println("removing modbus on port: ", bus.busNode.portName)
+			log.Println("removing modbus on port:", bus.busNode.portName)
 			bus.Stop()
 			delete(mm.busses, id)
 		}

--- a/node/modbus.go
+++ b/node/modbus.go
@@ -72,7 +72,7 @@ func NewModbus(nc *nats.Conn, node data.NodeEdge) (*Modbus, error) {
 			points, err := data.PbDecodePoints(msg.Data)
 			if err != nil {
 				// FIXME, send over channel
-				log.Println("Error decoding node data: ", err)
+				log.Println("Error decoding node data:", err)
 				return
 			}
 
@@ -96,7 +96,7 @@ func (b *Modbus) Stop() {
 	if b.sub != nil {
 		err := b.sub.Unsubscribe()
 		if err != nil {
-			log.Println("Error unsubscribing from bus: ", err)
+			log.Println("Error unsubscribing from bus:", err)
 		}
 	}
 	for _, io := range b.ios {
@@ -122,12 +122,12 @@ func (b *Modbus) CheckIOs() error {
 			var err error
 			ioNode, err := NewModbusIONode(b.busNode.busType, &node)
 			if err != nil {
-				log.Println("Error with IO node: ", err)
+				log.Println("Error with IO node:", err)
 				continue
 			}
 			io, err := NewModbusIO(b.nc, ioNode, b.chPoint)
 			if err != nil {
-				log.Println("Error creating new modbus IO: ", err)
+				log.Println("Error creating new modbus IO:", err)
 				continue
 			}
 			b.ios[node.ID] = io
@@ -140,7 +140,7 @@ func (b *Modbus) CheckIOs() error {
 		_, ok := found[id]
 		if !ok {
 			// io was deleted so close and clear it
-			log.Println("modbus io removed: ", io.ioNode.description)
+			log.Println("modbus io removed:", io.ioNode.description)
 			io.Stop()
 			delete(b.ios, id)
 		}
@@ -465,7 +465,7 @@ func regCount(regType string) int {
 		data.PointValueFLOAT32:
 		return 2
 	default:
-		log.Println("regCount, unknown data type: ", regType)
+		log.Println("regCount, unknown data type:", regType)
 		// be conservative
 		return 2
 	}
@@ -484,25 +484,25 @@ func (b *Modbus) InitRegs(io *ModbusIONode) {
 		b.regs.AddCoil(io.address)
 		err := b.regs.WriteCoil(io.address, data.FloatToBool(io.value))
 		if err != nil {
-			log.Println("Error writing coil: ", err)
+			log.Println("Error writing coil:", err)
 		}
 	case data.PointValueModbusCoil:
 		b.regs.AddCoil(io.address)
 		err := b.regs.WriteCoil(io.address, data.FloatToBool(io.value))
 		if err != nil {
-			log.Println("Error writing coil: ", err)
+			log.Println("Error writing coil:", err)
 		}
 	case data.PointValueModbusInputRegister:
 		b.regs.AddReg(io.address, regCount(io.modbusDataType))
 		err := b.WriteReg(io)
 		if err != nil {
-			log.Println("Error writing reg: ", err)
+			log.Println("Error writing reg:", err)
 		}
 	case data.PointValueModbusHoldingRegister:
 		b.regs.AddReg(io.address, regCount(io.modbusDataType))
 		err := b.WriteReg(io)
 		if err != nil {
-			log.Println("Error writing reg: ", err)
+			log.Println("Error writing reg:", err)
 		}
 	}
 }
@@ -640,7 +640,7 @@ func (b *Modbus) ClosePort() {
 	if b.server != nil {
 		err := b.server.Close()
 		if err != nil {
-			log.Println("Error closing server: ", err)
+			log.Println("Error closing server:", err)
 		}
 		b.server = nil
 	}
@@ -648,7 +648,7 @@ func (b *Modbus) ClosePort() {
 	if b.client != nil {
 		err := b.client.Close()
 		if err != nil {
-			log.Println("Error closing client: ", err)
+			log.Println("Error closing client:", err)
 		}
 		b.client = nil
 	}
@@ -657,7 +657,7 @@ func (b *Modbus) ClosePort() {
 // SetupPort sets up io for the bus
 func (b *Modbus) SetupPort() error {
 	if b.busNode.debugLevel >= 1 {
-		log.Println("modbus: setting up modbus transport: ", b.busNode.portName)
+		log.Println("modbus: setting up modbus transport:", b.busNode.portName)
 	}
 
 	b.ClosePort()
@@ -692,7 +692,7 @@ func (b *Modbus) SetupPort() error {
 		case data.PointValueServer:
 			// TCPServer does all the setup
 		default:
-			log.Println("setting up modbus TCP, invalid bus type: ", b.busNode.busType)
+			log.Println("setting up modbus TCP, invalid bus type:", b.busNode.busType)
 		}
 
 	default:
@@ -717,7 +717,7 @@ func (b *Modbus) SetupPort() error {
 		}
 
 		go b.server.Listen(func(err error) {
-			log.Println("Modbus server error: ", err)
+			log.Println("Modbus server error:", err)
 		}, func() {
 			if b.busNode.debugLevel > 0 {
 				log.Println("Modbus reg change")
@@ -762,7 +762,7 @@ func (b *Modbus) Run() {
 
 	checkIoTimer := time.NewTicker(time.Second * 10)
 
-	log.Println("initializing modbus port: ", b.busNode.portName)
+	log.Println("initializing modbus port:", b.busNode.portName)
 
 	for {
 		select {
@@ -773,7 +773,7 @@ func (b *Modbus) Run() {
 				var err error
 				b.busNode, err = NewModbusNode(b.node)
 				if err != nil {
-					log.Println("Error updating bus node: ", err)
+					log.Println("Error updating bus node:", err)
 				}
 
 				switch point.point.Type {
@@ -785,7 +785,7 @@ func (b *Modbus) Run() {
 					data.PointTypeURI:
 					err := b.SetupPort()
 					if err != nil {
-						log.Println("Error setting up serial port: ", err)
+						log.Println("Error setting up serial port:", err)
 					}
 				case data.PointTypePollPeriod:
 					setScanTimer()
@@ -795,13 +795,13 @@ func (b *Modbus) Run() {
 						p := data.Point{Type: data.PointTypeErrorCount, Value: 0}
 						err := client.SendNodePoint(b.nc, b.busNode.nodeID, p, true)
 						if err != nil {
-							log.Println("Send point error: ", err)
+							log.Println("Send point error:", err)
 						}
 
 						p = data.Point{Type: data.PointTypeErrorCountReset, Value: 0}
 						err = client.SendNodePoint(b.nc, b.busNode.nodeID, p, true)
 						if err != nil {
-							log.Println("Send point error: ", err)
+							log.Println("Send point error:", err)
 						}
 					}
 
@@ -810,13 +810,13 @@ func (b *Modbus) Run() {
 						p := data.Point{Type: data.PointTypeErrorCountCRC, Value: 0}
 						err := client.SendNodePoint(b.nc, b.busNode.nodeID, p, true)
 						if err != nil {
-							log.Println("Send point error: ", err)
+							log.Println("Send point error:", err)
 						}
 
 						p = data.Point{Type: data.PointTypeErrorCountCRCReset, Value: 0}
 						err = client.SendNodePoint(b.nc, b.busNode.nodeID, p, true)
 						if err != nil {
-							log.Println("Send point error: ", err)
+							log.Println("Send point error:", err)
 						}
 					}
 
@@ -825,20 +825,20 @@ func (b *Modbus) Run() {
 						p := data.Point{Type: data.PointTypeErrorCountEOF, Value: 0}
 						err := client.SendNodePoint(b.nc, b.busNode.nodeID, p, true)
 						if err != nil {
-							log.Println("Send point error: ", err)
+							log.Println("Send point error:", err)
 						}
 
 						p = data.Point{Type: data.PointTypeErrorCountEOFReset, Value: 0}
 						err = client.SendNodePoint(b.nc, b.busNode.nodeID, p, true)
 						if err != nil {
-							log.Println("Send point error: ", err)
+							log.Println("Send point error:", err)
 						}
 					}
 				}
 			} else {
 				io, ok := b.ios[point.id]
 				if !ok {
-					log.Println("modbus received point for unknown node: ", point.id)
+					log.Println("modbus received point for unknown node:", point.id)
 					// FIXME, we could create a new IO here
 					continue
 				}
@@ -885,13 +885,13 @@ func (b *Modbus) Run() {
 						p := data.Point{Type: data.PointTypeErrorCount, Value: 0}
 						err := client.SendNodePoint(b.nc, io.ioNode.nodeID, p, true)
 						if err != nil {
-							log.Println("Send point error: ", err)
+							log.Println("Send point error:", err)
 						}
 
 						p = data.Point{Type: data.PointTypeErrorCountReset, Value: 0}
 						err = client.SendNodePoint(b.nc, io.ioNode.nodeID, p, true)
 						if err != nil {
-							log.Println("Send point error: ", err)
+							log.Println("Send point error:", err)
 						}
 					}
 
@@ -901,13 +901,13 @@ func (b *Modbus) Run() {
 						p := data.Point{Type: data.PointTypeErrorCountEOF, Value: 0}
 						err := client.SendNodePoint(b.nc, io.ioNode.nodeID, p, true)
 						if err != nil {
-							log.Println("Send point error: ", err)
+							log.Println("Send point error:", err)
 						}
 
 						p = data.Point{Type: data.PointTypeErrorCountEOFReset, Value: 0}
 						err = client.SendNodePoint(b.nc, io.ioNode.nodeID, p, true)
 						if err != nil {
-							log.Println("Send point error: ", err)
+							log.Println("Send point error:", err)
 						}
 					}
 
@@ -917,17 +917,17 @@ func (b *Modbus) Run() {
 						p := data.Point{Type: data.PointTypeErrorCountCRC, Value: 0}
 						err := client.SendNodePoint(b.nc, io.ioNode.nodeID, p, true)
 						if err != nil {
-							log.Println("Send point error: ", err)
+							log.Println("Send point error:", err)
 						}
 
 						p = data.Point{Type: data.PointTypeErrorCountCRCReset, Value: 0}
 						err = client.SendNodePoint(b.nc, io.ioNode.nodeID, p, true)
 						if err != nil {
-							log.Println("Send point error: ", err)
+							log.Println("Send point error:", err)
 						}
 					}
 				default:
-					log.Println("modbus: unhandled io point: ", p)
+					log.Println("modbus: unhandled io point:", p)
 				}
 
 				if valueModified && b.busNode.busType == data.PointValueServer {
@@ -935,7 +935,7 @@ func (b *Modbus) Run() {
 					if err != nil {
 						err := b.LogError(io.ioNode, err)
 						if err != nil {
-							log.Println("Error logging error: ", err)
+							log.Println("Error logging error:", err)
 						}
 					}
 				}
@@ -948,7 +948,7 @@ func (b *Modbus) Run() {
 					if err != nil {
 						err := b.LogError(io.ioNode, err)
 						if err != nil {
-							log.Println("Error logging error: ", err)
+							log.Println("Error logging error:", err)
 						}
 					}
 				}
@@ -960,7 +960,7 @@ func (b *Modbus) Run() {
 				if err != nil {
 					err := b.LogError(io.ioNode, err)
 					if err != nil {
-						log.Println("Error logging modbus error: ", err)
+						log.Println("Error logging modbus error:", err)
 					}
 				}
 			}
@@ -984,11 +984,11 @@ func (b *Modbus) Run() {
 					b.ioErrorCount = 0
 					// try to set up port
 					if err := b.SetupPort(); err != nil {
-						log.Println("SetupPort error: ", err)
+						log.Println("SetupPort error:", err)
 					}
 				}
 				if err := b.CheckIOs(); err != nil {
-					log.Println("CheckIOs error: ", err)
+					log.Println("CheckIOs error:", err)
 				}
 			}
 
@@ -1003,13 +1003,13 @@ func (b *Modbus) Run() {
 					if err != nil {
 						err := b.LogError(io.ioNode, err)
 						if err != nil {
-							log.Println("Error logging modbus error: ", err)
+							log.Println("Error logging modbus error:", err)
 						}
 					}
 				}
 			}
 		case <-b.chDone:
-			log.Println("Stopping client IO for: ", b.busNode.portName)
+			log.Println("Stopping client IO for:", b.busNode.portName)
 			b.ClosePort()
 			return
 		}

--- a/node/node.go
+++ b/node/node.go
@@ -56,7 +56,7 @@ func (m *Manager) init() error {
 
 	appVer, ok := rootNode.Points.Find(data.PointTypeVersionApp, "")
 	if !ok || appVer.Text != m.appVersion {
-		log.Println("Setting app version: ", m.appVersion)
+		log.Println("Setting app version:", m.appVersion)
 		err := client.SendNodePoint(m.nc, rootNode.ID, data.Point{
 			Type: data.PointTypeVersionApp,
 			Text: m.appVersion,
@@ -70,12 +70,12 @@ func (m *Manager) init() error {
 	// check if OS version is current
 	osVer, err := system.ReadOSVersion(m.osVersionField)
 	if err != nil {
-		log.Println("Error reading OS version: ", err)
+		log.Println("Error reading OS version:", err)
 	} else {
-		log.Println("OS version: ", osVer)
+		log.Println("OS version:", osVer)
 		osVerStored, ok := rootNode.Points.Find(data.PointTypeVersionOS, "")
 		if !ok || osVer.String() != osVerStored.Text {
-			log.Println("Setting os version: ", osVer)
+			log.Println("Setting os version:", osVer)
 			err := client.SendNodePoint(m.nc, rootNode.ID, data.Point{
 				Type: data.PointTypeVersionOS,
 				Text: osVer.String(),
@@ -124,7 +124,7 @@ func (m *Manager) Start() error {
 		// TODO: this will not scale and needs to be made event driven
 		nodes, err := m.db.Nodes()
 		if err != nil {
-			log.Println("Error getting nodes: ", err)
+			log.Println("Error getting nodes:", err)
 			time.Sleep(10 * time.Second)
 			continue
 		}
@@ -141,7 +141,7 @@ func (m *Manager) Start() error {
 
 				err := client.SendNodePoint(m.nc, node.ID, p, false)
 				if err != nil {
-					log.Println("Error updating node state: ", err)
+					log.Println("Error updating node state:", err)
 				}
 			}
 		}

--- a/node/onewire-io.go
+++ b/node/onewire-io.go
@@ -34,7 +34,7 @@ func newOneWireIO(nc *nats.Conn, node *oneWireIONode, chPoint chan<- pointWID) (
 		points, err := data.PbDecodePoints(msg.Data)
 		if err != nil {
 			// FIXME, send over channel
-			log.Println("Error decoding node data: ", err)
+			log.Println("Error decoding node data:", err)
 			return
 		}
 
@@ -55,7 +55,7 @@ func (io *oneWireIO) stop() {
 	if io.sub != nil {
 		err := io.sub.Unsubscribe()
 		if err != nil {
-			log.Println("Error unsubscribing from IO: ", err)
+			log.Println("Error unsubscribing from IO:", err)
 		}
 	}
 }
@@ -85,12 +85,12 @@ func (io *oneWireIO) point(p data.Point) error {
 
 			err := client.SendNodePoints(io.nc, io.ioNode.nodeID, p, true)
 			if err != nil {
-				log.Println("Send point error: ", err)
+				log.Println("Send point error:", err)
 			}
 		}
 
 	default:
-		log.Println("1-wire: unhandled io point: ", p)
+		log.Println("1-wire: unhandled io point:", p)
 	}
 
 	return nil

--- a/node/onewire-manager.go
+++ b/node/onewire-manager.go
@@ -45,7 +45,7 @@ func (owm *oneWireManager) update() error {
 			var err error
 			bus, err := newOneWire(owm.nc, node)
 			if err != nil {
-				log.Println("Error creating new modbus: ", err)
+				log.Println("Error creating new modbus:", err)
 				continue
 			}
 			owm.busses[node.ID] = bus
@@ -57,7 +57,7 @@ func (owm *oneWireManager) update() error {
 		_, ok := found[id]
 		if !ok {
 			// bus was deleted so close and clear it
-			log.Println("removing onewire bus: ", bus.owNode.description)
+			log.Println("removing onewire bus:", bus.owNode.description)
 			bus.stop()
 			delete(owm.busses, id)
 		}
@@ -77,7 +77,7 @@ func (owm *oneWireManager) update() error {
 			index, err := strconv.Atoi(ms[1])
 
 			if err != nil {
-				log.Println("Error extracting 1-wire bus number: ", err)
+				log.Println("Error extracting 1-wire bus number:", err)
 			}
 
 			// loop through busses and make sure it exists
@@ -109,7 +109,7 @@ func (owm *oneWireManager) update() error {
 
 				err := client.SendNode(owm.nc, n, "")
 				if err != nil {
-					log.Println("Error sending new 1-wire node: ", err)
+					log.Println("Error sending new 1-wire node:", err)
 				}
 			}
 		}

--- a/node/onewire.go
+++ b/node/onewire.go
@@ -47,7 +47,7 @@ func newOneWire(nc *nats.Conn, node data.NodeEdge) (*oneWire, error) {
 			points, err := data.PbDecodePoints(msg.Data)
 			if err != nil {
 				// FIXME, send over channel
-				log.Println("Error decoding node data: ", err)
+				log.Println("Error decoding node data:", err)
 				return
 			}
 
@@ -71,7 +71,7 @@ func (ow *oneWire) stop() {
 	if ow.sub != nil {
 		err := ow.sub.Unsubscribe()
 		if err != nil {
-			log.Println("Error unsubscribing from bus: ", err)
+			log.Println("Error unsubscribing from bus:", err)
 		}
 	}
 	for _, io := range ow.ios {
@@ -97,12 +97,12 @@ func (ow *oneWire) CheckIOs() error {
 			var err error
 			ioNode, err := newOneWireIONode(&node)
 			if err != nil {
-				log.Println("Error with IO node: ", err)
+				log.Println("Error with IO node:", err)
 				continue
 			}
 			io, err := newOneWireIO(ow.nc, ioNode, ow.chPoint)
 			if err != nil {
-				log.Println("Error creating new modbus IO: ", err)
+				log.Println("Error creating new modbus IO:", err)
 				continue
 			}
 			ow.ios[node.ID] = io
@@ -114,7 +114,7 @@ func (ow *oneWire) CheckIOs() error {
 		_, ok := found[id]
 		if !ok {
 			// io was deleted so close and clear it
-			log.Println("modbus io removed: ", io.ioNode.description)
+			log.Println("modbus io removed:", io.ioNode.description)
 			io.stop()
 			delete(ow.ios, id)
 		}
@@ -140,12 +140,12 @@ func (ow *oneWire) checkIOs() error {
 			var err error
 			ioNode, err := newOneWireIONode(&node)
 			if err != nil {
-				log.Println("Error with IO node: ", err)
+				log.Println("Error with IO node:", err)
 				continue
 			}
 			io, err := newOneWireIO(ow.nc, ioNode, ow.chPoint)
 			if err != nil {
-				log.Println("Error creating new modbus IO: ", err)
+				log.Println("Error creating new modbus IO:", err)
 				continue
 			}
 			ow.ios[node.ID] = io
@@ -157,7 +157,7 @@ func (ow *oneWire) checkIOs() error {
 		_, ok := found[id]
 		if !ok {
 			// io was deleted so close and clear it
-			log.Println("modbus io removed: ", io.ioNode.description)
+			log.Println("modbus io removed:", io.ioNode.description)
 			io.stop()
 			delete(ow.ios, id)
 		}
@@ -183,7 +183,7 @@ func (ow *oneWire) detect() {
 			}
 
 			if !found {
-				log.Println("adding 1-wire IO: ", id)
+				log.Println("adding 1-wire IO:", id)
 
 				n := data.NodeEdge{
 					Type:   data.NodeTypeOneWireIO,
@@ -202,7 +202,7 @@ func (ow *oneWire) detect() {
 
 				err := client.SendNode(ow.nc, n, "")
 				if err != nil {
-					log.Println("Error sending new 1-wire IO: ", err)
+					log.Println("Error sending new 1-wire IO:", err)
 				}
 			}
 		}
@@ -232,7 +232,7 @@ func (ow *oneWire) run() {
 				var err error
 				ow.owNode, err = newOneWireNode(ow.node)
 				if err != nil {
-					log.Println("Error updating OW node: ", err)
+					log.Println("Error updating OW node:", err)
 				}
 
 				switch point.point.Type {
@@ -243,13 +243,13 @@ func (ow *oneWire) run() {
 						p := data.Point{Type: data.PointTypeErrorCount, Value: 0}
 						err := client.SendNodePoint(ow.nc, ow.owNode.nodeID, p, true)
 						if err != nil {
-							log.Println("Send point error: ", err)
+							log.Println("Send point error:", err)
 						}
 
 						p = data.Point{Type: data.PointTypeErrorCountReset, Value: 0}
 						err = client.SendNodePoint(ow.nc, ow.owNode.nodeID, p, true)
 						if err != nil {
-							log.Println("Send point error: ", err)
+							log.Println("Send point error:", err)
 						}
 					}
 				}
@@ -258,7 +258,7 @@ func (ow *oneWire) run() {
 
 			io, ok := ow.ios[point.id]
 			if !ok {
-				log.Println("1-wire received point for unknown node: ", point.id)
+				log.Println("1-wire received point for unknown node:", point.id)
 				continue
 			}
 
@@ -276,7 +276,7 @@ func (ow *oneWire) run() {
 
 			err := ow.checkIOs()
 			if err != nil {
-				log.Println("Error checking 1-wire ios: ", err)
+				log.Println("Error checking 1-wire ios:", err)
 			}
 			ow.detect()
 			for _, io := range ow.ios {
@@ -294,7 +294,7 @@ func (ow *oneWire) run() {
 						Value: float64(busCount),
 					}, false)
 					if err != nil {
-						log.Println("Error sending point: ", err)
+						log.Println("Error sending point:", err)
 					}
 
 					err = client.SendNodePoint(ow.nc, io.ioNode.nodeID, data.Point{
@@ -302,7 +302,7 @@ func (ow *oneWire) run() {
 						Value: float64(ioCount),
 					}, false)
 					if err != nil {
-						log.Println("Error sending point: ", err)
+						log.Println("Error sending point:", err)
 					}
 				}
 			}

--- a/server/args.go
+++ b/server/args.go
@@ -53,7 +53,7 @@ func Args(args []string, flags *flag.FlagSet) (Options, error) {
 	err := files.UpdateFiles(dataDir)
 
 	if err != nil {
-		log.Println("Error updating files: ", err)
+		log.Println("Error updating files:", err)
 		os.Exit(-1)
 	}
 
@@ -70,7 +70,7 @@ func Args(args []string, flags *flag.FlagSet) (Options, error) {
 	if natsPortE != "" {
 		n, err := strconv.Atoi(natsPortE)
 		if err != nil {
-			log.Println("Error parsing SIOT_NATS_PORT: ", err)
+			log.Println("Error parsing SIOT_NATS_PORT:", err)
 			os.Exit(-1)
 		}
 		natsPort = n
@@ -82,7 +82,7 @@ func Args(args []string, flags *flag.FlagSet) (Options, error) {
 	if natsHTTPPortE != "" {
 		n, err := strconv.Atoi(natsHTTPPortE)
 		if err != nil {
-			log.Println("Error parsing SIOT_NATS_HTTP_PORT: ", err)
+			log.Println("Error parsing SIOT_NATS_HTTP_PORT:", err)
 			os.Exit(-1)
 		}
 		natsHTTPPort = n
@@ -93,7 +93,7 @@ func Args(args []string, flags *flag.FlagSet) (Options, error) {
 	if natsWSPortE != "" {
 		n, err := strconv.Atoi(natsWSPortE)
 		if err != nil {
-			log.Println("Error parsing SIOT_NATS_WS_PORT: ", err)
+			log.Println("Error parsing SIOT_NATS_WS_PORT:", err)
 			os.Exit(-1)
 		}
 		natsWSPort = n
@@ -118,7 +118,7 @@ func Args(args []string, flags *flag.FlagSet) (Options, error) {
 	if natsTLSTimeoutS != "" {
 		natsTLSTimeout, err = strconv.ParseFloat(natsTLSTimeoutS, 64)
 		if err != nil {
-			log.Println("Error parsing nats TLS timeout: ", err)
+			log.Println("Error parsing nats TLS timeout:", err)
 			os.Exit(-1)
 		}
 	}
@@ -131,7 +131,7 @@ func Args(args []string, flags *flag.FlagSet) (Options, error) {
 	if *flagSyslog {
 		err := system.EnableSyslog()
 		if err != nil {
-			log.Println("Error enabling syslog: ", err)
+			log.Println("Error enabling syslog:", err)
 		}
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -308,7 +308,7 @@ func (s *Server) Run() error {
 	var feFS fs.FS
 
 	if o.CustomUIDir != "" {
-		log.Println("Using custom frontend directory: ", o.CustomUIDir)
+		log.Println("Using custom frontend directory:", o.CustomUIDir)
 		feFS = os.DirFS(o.CustomUIDir)
 	} else if o.CustomUIFS != nil {
 		feFS = o.CustomUIFS
@@ -359,7 +359,7 @@ func (s *Server) Run() error {
 		log.Println("List frontend assets: ")
 		err := listFiles(feFS, ".", 0)
 		if err != nil {
-			log.Println("Error listing frontend assets: ", err)
+			log.Println("Error listing frontend assets:", err)
 		}
 	}
 

--- a/server/test-server.go
+++ b/server/test-server.go
@@ -63,7 +63,7 @@ func TestServer(args ...string) (*nats.Conn, data.NodeEdge, func(), error) {
 	go func() {
 		err := s.Run()
 		if err != nil {
-			log.Println("Test Server start returned: ", err)
+			log.Println("Test Server start returned:", err)
 		}
 		close(stopped)
 	}()

--- a/sim/node.go
+++ b/sim/node.go
@@ -42,7 +42,7 @@ func NodeSim(portal, nodeID string) {
 
 		err := sendPoints(points)
 		if err != nil {
-			log.Println("Error sending points: ", err)
+			log.Println("Error sending points:", err)
 		}
 		packetDelay()
 	}

--- a/store/notification.go
+++ b/store/notification.go
@@ -6,7 +6,7 @@ package store
 func (st *Store) handleNotification(msg *nats.Msg) {
 	chunks := strings.Split(msg.Subject, ".")
 	if len(chunks) < 2 {
-		log.Println("Error in message subject: ", msg.Subject)
+		log.Println("Error in message subject:", msg.Subject)
 		return
 	}
 
@@ -15,7 +15,7 @@ func (st *Store) handleNotification(msg *nats.Msg) {
 	not, err := data.PbDecodeNotification(msg.Data)
 
 	if err != nil {
-		log.Println("Error decoding Pb notification: ", err)
+		log.Println("Error decoding Pb notification:", err)
 		return
 	}
 
@@ -26,7 +26,7 @@ func (st *Store) handleNotification(msg *nats.Msg) {
 		findUsers = func(id string) {
 			nodes, err := st.db.getNodes(nil, "all", id, data.NodeTypeUser, false)
 			if err != nil {
-				log.Println("Error find user nodes: ", err)
+				log.Println("Error find user nodes:", err)
 				return
 			}
 
@@ -38,7 +38,7 @@ func (st *Store) handleNotification(msg *nats.Msg) {
 			// now process upstream nodes
 			upIDs := st.db.edgeUp(id, false)
 			if err != nil {
-				log.Println("Error getting upstream nodes: ", err)
+				log.Println("Error getting upstream nodes:", err)
 				return
 			}
 
@@ -50,7 +50,7 @@ func (st *Store) handleNotification(msg *nats.Msg) {
 			node, err := st.db.node(nodeID)
 
 			if err != nil {
-				log.Println("Error getting node: ", nodeID)
+				log.Println("Error getting node:", nodeID)
 				return
 			}
 
@@ -66,7 +66,7 @@ func (st *Store) handleNotification(msg *nats.Msg) {
 		user, err := data.NodeToUser(userNode.ToNode())
 
 		if err != nil {
-			log.Println("Error converting node to user: ", err)
+			log.Println("Error converting node to user:", err)
 			continue
 		}
 
@@ -85,14 +85,14 @@ func (st *Store) handleNotification(msg *nats.Msg) {
 			data, err := msg.ToPb()
 
 			if err != nil {
-				log.Println("Error serializing msg to protobuf: ", err)
+				log.Println("Error serializing msg to protobuf:", err)
 				continue
 			}
 
 			err = st.nc.Publish("node."+user.ID+".msg", data)
 
 			if err != nil {
-				log.Println("Error publishing message: ", err)
+				log.Println("Error publishing message:", err)
 				continue
 			}
 		}
@@ -102,7 +102,7 @@ func (st *Store) handleNotification(msg *nats.Msg) {
 func (st *Store) handleMessage(natsMsg *nats.Msg) {
 	chunks := strings.Split(natsMsg.Subject, ".")
 	if len(chunks) < 2 {
-		log.Println("Error in message subject: ", natsMsg.Subject)
+		log.Println("Error in message subject:", natsMsg.Subject)
 		return
 	}
 
@@ -111,7 +111,7 @@ func (st *Store) handleMessage(natsMsg *nats.Msg) {
 	message, err := data.PbDecodeMessage(natsMsg.Data)
 
 	if err != nil {
-		log.Println("Error decoding Pb message: ", err)
+		log.Println("Error decoding Pb message:", err)
 		return
 	}
 
@@ -124,7 +124,7 @@ func (st *Store) handleMessage(natsMsg *nats.Msg) {
 	findSvcNodes = func(id string) {
 		nodes, err := st.db.getNodes(nil, "all", id, data.NodeTypeMsgService, false)
 		if err != nil {
-			log.Println("Error getting svc descendents: ", err)
+			log.Println("Error getting svc descendents:", err)
 			return
 		}
 
@@ -144,7 +144,7 @@ func (st *Store) handleMessage(natsMsg *nats.Msg) {
 		} else {
 			upIDs = st.db.edgeUp(id, false)
 			if err != nil {
-				log.Println("Error getting upstream nodes: ", err)
+				log.Println("Error getting upstream nodes:", err)
 				return
 			}
 		}
@@ -163,7 +163,7 @@ func (st *Store) handleMessage(natsMsg *nats.Msg) {
 	for _, svcNode := range svcNodes {
 		svc, err := data.NodeToMsgService(svcNode.ToNode())
 		if err != nil {
-			log.Println("Error converting node to msg service: ", err)
+			log.Println("Error converting node to msg service:", err)
 			continue
 		}
 

--- a/store/sqlite.go
+++ b/store/sqlite.go
@@ -41,7 +41,7 @@ func NewSqliteDb(dbFile string, rootID string) (*DbSqlite, error) {
 
 	dbFileOptions := fmt.Sprintf("%s?%s", dbFile, pragmas)
 
-	log.Println("Open store: ", dbFileOptions)
+	log.Println("Open store:", dbFileOptions)
 
 	db, err := sql.Open("sqlite", dbFileOptions)
 	if err != nil {
@@ -271,7 +271,7 @@ func (sdb *DbSqlite) verifyNodeHashes(fix bool) error {
 	rollback := func() {
 		rbErr := tx.Rollback()
 		if rbErr != nil {
-			log.Println("Rollback error: ", rbErr)
+			log.Println("Rollback error:", rbErr)
 		}
 	}
 
@@ -431,7 +431,7 @@ func (sdb *DbSqlite) nodePoints(id string, points data.Points) error {
 	rollback := func() {
 		rbErr := tx.Rollback()
 		if rbErr != nil {
-			log.Println("Rollback error: ", rbErr)
+			log.Println("Rollback error:", rbErr)
 		}
 	}
 
@@ -492,7 +492,7 @@ NextPin:
 					hashUpdate ^= pDb.CRC()
 					hashUpdate ^= pIn.CRC()
 				} else {
-					log.Println("Ignoring node point due to timestamps: ", id, pIn)
+					log.Println("Ignoring node point due to timestamps:", id, pIn)
 				}
 				continue NextPin
 			}
@@ -527,7 +527,7 @@ NextPin:
 	defer func() {
 		err := stmt.Close()
 		if err != nil {
-			log.Println("Error closing sqlite statement: ", err)
+			log.Println("Error closing sqlite statement:", err)
 		}
 	}()
 
@@ -589,7 +589,7 @@ func (sdb *DbSqlite) edgePoints(nodeID, parentID string, points data.Points) err
 	rollback := func() {
 		rbErr := tx.Rollback()
 		if rbErr != nil {
-			log.Println("Rollback error: ", rbErr)
+			log.Println("Rollback error:", rbErr)
 		}
 	}
 
@@ -675,7 +675,7 @@ NextPin:
 					hashUpdate ^= pDb.CRC()
 					hashUpdate ^= pIn.CRC()
 				} else {
-					log.Println("Ignoring edge point due to timestamps: ", edge.ID, pIn)
+					log.Println("Ignoring edge point due to timestamps:", edge.ID, pIn)
 				}
 				continue NextPin
 			}
@@ -772,7 +772,7 @@ NextPin:
 		// (hash will be populated later)
 
 		if err != nil {
-			log.Println("edge insert failed, trying again ...: ", err)
+			log.Println("edge insert failed, trying again ...:", err)
 			// FIXME, occasionally the above INSERT will fail with "database is locked (5) (SQLITE_BUSY)"
 			// FIXME, not sure if retry is required any more since we removed the nested
 			// queries
@@ -1075,7 +1075,7 @@ func (sdb *DbSqlite) userCheck(email, password string) (data.Nodes, error) {
 		var id string
 		err = rows.Scan(&id)
 		if err != nil {
-			log.Println("Error scanning user id: ", id)
+			log.Println("Error scanning user id:", id)
 			continue
 		}
 
@@ -1089,7 +1089,7 @@ func (sdb *DbSqlite) userCheck(email, password string) (data.Nodes, error) {
 	for _, id := range ids {
 		ne, err := sdb.getNodes(nil, "all", id, "", false)
 		if err != nil {
-			log.Println("Error getting user node for id: ", id)
+			log.Println("Error getting user node for id:", id)
 			continue
 		}
 		if len(ne) < 1 {

--- a/store/store.go
+++ b/store/store.go
@@ -67,7 +67,7 @@ func NewStore(p Params) (*Store, error) {
 		return nil, fmt.Errorf("Error creating authorizer: %v", err)
 	}
 
-	log.Println("store connecting to nats server: ", p.Server)
+	log.Println("store connecting to nats server:", p.Server)
 	return &Store{
 		params:        p,
 		nc:            p.Nc,
@@ -215,22 +215,22 @@ func (st *Store) StartMetrics(nodeID string) error {
 		case <-t.C:
 			pendingNodePoints, _, err := st.subscriptions["nodePoints"].Pending()
 			if err != nil {
-				log.Println("Error getting pendingNodePoints: ", err)
+				log.Println("Error getting pendingNodePoints:", err)
 			}
 
 			err = st.metricPendingNodePoint.AddSample(float64(pendingNodePoints))
 			if err != nil {
-				log.Println("Error handling metric: ", err)
+				log.Println("Error handling metric:", err)
 			}
 
 			pendingEdgePoints, _, err := st.subscriptions["edgePoints"].Pending()
 			if err != nil {
-				log.Println("Error getting pendingEdgePoints: ", err)
+				log.Println("Error getting pendingEdgePoints:", err)
 			}
 
 			err = st.metricPendingNodeEdgePoint.AddSample(float64(pendingEdgePoints))
 			if err != nil {
-				log.Println("Error handling metric: ", err)
+				log.Println("Error handling metric:", err)
 			}
 			t.Reset(time.Second * 10)
 		}
@@ -248,7 +248,7 @@ func (st *Store) handleNodePoints(msg *nats.Msg) {
 		t := time.Since(start).Milliseconds()
 		err := st.metricCycleNodePoint.AddSample(float64(t))
 		if err != nil {
-			log.Println("Error stopping metrics: ", err)
+			log.Println("Error stopping metrics:", err)
 		}
 	}()
 
@@ -266,7 +266,7 @@ func (st *Store) handleNodePoints(msg *nats.Msg) {
 	if err != nil {
 		// TODO track error stats
 		log.Printf("Error writing nodeID (%v) to Db: %v", nodeID, err)
-		log.Println("msg subject: ", msg.Subject)
+		log.Println("msg subject:", msg.Subject)
 		st.reply(msg.Reply, err)
 		return
 	}
@@ -275,7 +275,7 @@ func (st *Store) handleNodePoints(msg *nats.Msg) {
 	err = st.processPointsUpstream(nodeID, nodeID, points)
 	if err != nil {
 		// TODO track error stats
-		log.Println("Error processing point in upstream nodes: ", err)
+		log.Println("Error processing point in upstream nodes:", err)
 	}
 
 	st.reply(msg.Reply, nil)
@@ -287,7 +287,7 @@ func (st *Store) handleEdgePoints(msg *nats.Msg) {
 		t := time.Since(start).Milliseconds()
 		err := st.metricCycleNodeEdgePoint.AddSample(float64(t))
 		if err != nil {
-			log.Println("handle edge point error: ", err)
+			log.Println("handle edge point error:", err)
 		}
 	}()
 
@@ -315,7 +315,7 @@ func (st *Store) handleEdgePoints(msg *nats.Msg) {
 	err = st.processEdgePointsUpstream(nodeID, nodeID, parentID, points)
 	if err != nil {
 		// TODO track error stats
-		log.Println("Error processing point in upstream nodes: ", err)
+		log.Println("Error processing point in upstream nodes:", err)
 	}
 
 	st.reply(msg.Reply, nil)
@@ -327,7 +327,7 @@ func (st *Store) handleNodesRequest(msg *nats.Msg) {
 		t := time.Since(start).Milliseconds()
 		err := st.metricCycleNode.AddSample(float64(t))
 		if err != nil {
-			log.Println("handleNodesRequest error: ", err)
+			log.Println("handleNodesRequest error:", err)
 		}
 	}()
 
@@ -383,13 +383,13 @@ handleNodeDone:
 
 	data, err := proto.Marshal(resp)
 	if err != nil {
-		log.Println("marshal error: ", err)
+		log.Println("marshal error:", err)
 		return
 	}
 
 	err = st.nc.Publish(msg.Reply, data)
 	if err != nil {
-		log.Println("NATS: Error publishing response to node request: ", err)
+		log.Println("NATS: Error publishing response to node request:", err)
 	}
 }
 
@@ -414,7 +414,7 @@ func (st *Store) handleAuthUser(msg *nats.Msg) {
 
 	points, err = data.PbDecodePoints(msg.Data)
 	if err != nil {
-		log.Println("Error decoding auth.user params: ", err)
+		log.Println("Error decoding auth.user params:", err)
 		returnNothing()
 		return
 	}
@@ -470,7 +470,7 @@ func (st *Store) handleAuthUser(msg *nats.Msg) {
 
 	err = st.nc.Publish(msg.Reply, data)
 	if err != nil {
-		log.Println("NATS: Error publishing response to node request: ", err)
+		log.Println("NATS: Error publishing response to node request:", err)
 	}
 }
 
@@ -488,7 +488,7 @@ func (st *Store) handleAuthGetNatsURI(msg *nats.Msg) {
 
 	err = st.nc.Publish(msg.Reply, data)
 	if err != nil {
-		log.Println("NATS: Error publishing response to gets NATS URI request: ", err)
+		log.Println("NATS: Error publishing response to gets NATS URI request:", err)
 	}
 }
 
@@ -501,7 +501,7 @@ func (st *Store) handleStoreVerify(msg *nats.Msg) {
 
 	err := st.nc.Publish(msg.Reply, []byte(ret))
 	if err != nil {
-		log.Println("NATS: Error publishing response to node request: ", err)
+		log.Println("NATS: Error publishing response to node request:", err)
 	}
 }
 
@@ -514,7 +514,7 @@ func (st *Store) handleStoreMaint(msg *nats.Msg) {
 
 	err := st.nc.Publish(msg.Reply, []byte(ret))
 	if err != nil {
-		log.Println("NATS: Error publishing response to node request: ", err)
+		log.Println("NATS: Error publishing response to node request:", err)
 	}
 }
 
@@ -533,7 +533,7 @@ func (st *Store) reply(subject string, err error) {
 
 	e := st.nc.Publish(subject, []byte(reply))
 	if e != nil {
-		log.Println("Error ack reply: ", e)
+		log.Println("Error ack reply:", e)
 	}
 }
 
@@ -560,7 +560,7 @@ func (st *Store) processPointsUpstream(upNodeID, nodeID string, points data.Poin
 	for _, up := range ups {
 		err = st.processPointsUpstream(up, nodeID, points)
 		if err != nil {
-			log.Println("Rules -- error processing upstream node: ", err)
+			log.Println("Rules -- error processing upstream node:", err)
 		}
 	}
 
@@ -570,7 +570,7 @@ func (st *Store) processPointsUpstream(upNodeID, nodeID string, points data.Poin
 		// check if device node that it has not been orphaned
 		node, err := st.db.node(nodeID)
 		if err != nil {
-			log.Println("Error getting node: ", err)
+			log.Println("Error getting node:", err)
 		}
 
 		if node.Type == data.NodeTypeDevice {
@@ -590,7 +590,7 @@ func (st *Store) processPointsUpstream(upNodeID, nodeID string, points data.Poin
 						Value: 0,
 					}, false)
 					if err != nil {
-						log.Println("Error sending edge point: ", err)
+						log.Println("Error sending edge point:", err)
 					}
 				} else {
 					// undelete existing edge
@@ -600,7 +600,7 @@ func (st *Store) processPointsUpstream(upNodeID, nodeID string, points data.Poin
 						Value: 0,
 					}, false)
 					if err != nil {
-						log.Println("Error sending edge point: ", err)
+						log.Println("Error sending edge point:", err)
 					}
 				}
 			}
@@ -633,7 +633,7 @@ func (st *Store) processEdgePointsUpstream(upNodeID, nodeID, parentID string, po
 	for _, up := range ups {
 		err = st.processEdgePointsUpstream(up, nodeID, parentID, points)
 		if err != nil {
-			log.Println("Rules -- error processing upstream node: ", err)
+			log.Println("Rules -- error processing upstream node:", err)
 		}
 	}
 

--- a/system/time-common.go
+++ b/system/time-common.go
@@ -11,7 +11,7 @@ func UpdateTimeFromNetwork() (err error) {
 
 	current, err := ntp.Time("0.pool.ntp.org")
 	if err != nil {
-		log.Println("Error fetching time from ntp.org: ", err)
+		log.Println("Error fetching time from ntp.org:", err)
 		return err
 	}
 

--- a/system/time_linux.go
+++ b/system/time_linux.go
@@ -15,7 +15,7 @@ func SetTime(t time.Time) (err error) {
 	tv := syscall.NsecToTimeval(t.UnixNano())
 	err = syscall.Settimeofday(&tv)
 	if err != nil {
-		log.Println("Error synchronizing system clock: ", err)
+		log.Println("Error synchronizing system clock:", err)
 		return err
 	}
 


### PR DESCRIPTION
`log.Println` adds an extra space automatically

Searched using regex /log\.Println\(\"([^"]+)(\s+)\"\,/ and replacing with log.Println("\1",

# Checklist

Please verify this PR includes the following if relevant:

- [x] `siot_test` passes
- [x] `CHANGELOG.md` entry created/updated
- [x] [docs/](https://github.com/simpleiot/simpleiot/tree/master/docs)
      created/updated

Thanks!
