### PR TITLE
db: Improve Influx history query functionality

### DIFF
--- a/client/db.go
+++ b/client/db.go
@@ -146,6 +146,20 @@ func (dbc *DbClient) Run() error {
 			} else {
 				err = msg.Respond(res)
 				if err != nil {
+					// Try responding via NATS with the error
+					results = &data.HistoryResults{
+						ErrorMessage: err.Error(),
+					}
+					res, parseErr := json.Marshal(results)
+					if parseErr == nil {
+						retryError := msg.Respond(res)
+						if retryError == nil {
+							// clear original error
+							err = nil
+						}
+					}
+				}
+				if err != nil {
 					log.Printf("error responding to history query: %v", err)
 				}
 			}


### PR DESCRIPTION
- If history query response fails, try responding again with ErrorMessage
- TagFilters values can now be empty string or a slice of strings

# Checklist

Please verify this PR includes the following if relevant:

- [ ] `siot_test` passes
- [ ] `CHANGELOG.md` entry created/updated
- [ ] [docs/](https://github.com/simpleiot/simpleiot/tree/master/docs)
      created/updated

Thanks!
