### PR TITLE
feat(modbus): Add support for writing multiple regs

### DIFF
--- a/modbus/client.go
+++ b/modbus/client.go
@@ -338,12 +338,12 @@ func (c *Client) WriteSingleReg(id byte, reg, value uint16) error {
 	return nil
 }
 
-// WriteMultipleReg writes to multiple holding registers
-func (c *Client) WriteMultipleReg(id byte, reg, quantity uint16, values []uint16) error {
-	req := WriteMultipleReg(reg, quantity, values)
+// WriteMultipleRegs writes to multiple holding registers
+func (c *Client) WriteMultipleRegs(id byte, reg, quantity uint16, values []uint16) error {
+	req := WriteMultipleRegs(reg, quantity, values)
 
 	if c.debug >= 1 {
-		fmt.Printf("Modbus client WriteMultipleReg ID:0x%x req:%v\n", id, req)
+		fmt.Printf("Modbus client WriteMultipleRegs ID:0x%x req:%v\n", id, req)
 	}
 
 	packet, err := c.transport.Encode(id, req)
@@ -352,7 +352,7 @@ func (c *Client) WriteMultipleReg(id byte, reg, quantity uint16, values []uint16
 	}
 
 	if c.debug >= 9 {
-		fmt.Println("Modbus client WriteMultipleReg tx: ", test.HexDump(packet))
+		fmt.Println("Modbus client WriteMultipleRegs tx: ", test.HexDump(packet))
 	}
 
 	_, err = c.transport.Write(packet)
@@ -370,7 +370,7 @@ func (c *Client) WriteMultipleReg(id byte, reg, quantity uint16, values []uint16
 	buf = buf[:cnt]
 
 	if c.debug >= 9 {
-		fmt.Println("Modbus client WriteMultipleReg rx: ", test.HexDump(buf))
+		fmt.Println("Modbus client WriteMultipleRegs rx: ", test.HexDump(buf))
 	}
 
 	_, resp, err := c.transport.Decode(buf)
@@ -379,7 +379,7 @@ func (c *Client) WriteMultipleReg(id byte, reg, quantity uint16, values []uint16
 	}
 
 	if c.debug >= 1 {
-		fmt.Printf("Modbus client WriteMultipleReg ID:0x%x resp:%v\n", id, resp)
+		fmt.Printf("Modbus client WriteMultipleRegs ID:0x%x resp:%v\n", id, resp)
 	}
 	
 	if resp.FunctionCode != req.FunctionCode {

--- a/modbus/client.go
+++ b/modbus/client.go
@@ -381,7 +381,7 @@ func (c *Client) WriteMultipleRegs(id byte, reg, quantity uint16, values []uint1
 	if c.debug >= 1 {
 		fmt.Printf("Modbus client WriteMultipleRegs ID:0x%x resp:%v\n", id, resp)
 	}
-	
+
 	if resp.FunctionCode != req.FunctionCode {
 		return errors.New("resp contains wrong function code")
 	}

--- a/modbus/pdu.go
+++ b/modbus/pdu.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/simpleiot/simpleiot/test"
 )
@@ -250,12 +251,27 @@ func WriteSingleCoil(address uint16, v bool) PDU {
 	}
 }
 
-// WriteSingleReg creates PDU to read coils
+// WriteSingleReg creates PDU to write a single holding reg
 func WriteSingleReg(address, value uint16) PDU {
 	return PDU{
 		FunctionCode: FuncCodeWriteSingleRegister,
 		Data:         PutUint16Array(address, value),
 	}
+}
+
+// WriteMultipleReg creates PDU to write multiple holding regs
+func WriteMultipleReg(address uint16, quantity uint16, values []uint16) PDU {
+	return PDU{
+		FunctionCode: FuncCodeWriteMultipleRegisters,
+		Data:         putUint16ArrayWithByteCount(address, quantity, values),
+	}
+}
+
+func putUint16ArrayWithByteCount(address uint16, quantity uint16, values []uint16) []byte {
+	addressAndQuantity := PutUint16Array(address, quantity)
+	byteCount := []byte{byte(uint8(quantity * 2))}
+	data := PutUint16Array(values...)
+	return slices.Concat(addressAndQuantity, byteCount, data)
 }
 
 // ReadHoldingRegs creates a PDU to read a holding regs

--- a/modbus/pdu.go
+++ b/modbus/pdu.go
@@ -259,8 +259,8 @@ func WriteSingleReg(address, value uint16) PDU {
 	}
 }
 
-// WriteMultipleReg creates PDU to write multiple holding regs
-func WriteMultipleReg(address uint16, quantity uint16, values []uint16) PDU {
+// WriteMultipleRegs creates PDU to write multiple holding regs
+func WriteMultipleRegs(address uint16, quantity uint16, values []uint16) PDU {
 	return PDU{
 		FunctionCode: FuncCodeWriteMultipleRegisters,
 		Data:         putUint16ArrayWithByteCount(address, quantity, values),


### PR DESCRIPTION
This PR adds the capability to write multiple regs, for example I would use it like this:

```go
id := byte(1)
regs := modbus.Int32ToRegs([]int32{power}) // power in Watts
err = client.WriteMultipleRegs(id, uint16(47321), uint16(2), regs)
```

Right now only `client.WriteSingleReg` is supported, and at first I thought I'd just use that twice, but this can't be used to write multiple regs since it's a completely different request, as detailed here: https://ozeki.hu/p_5883-mobdbus-function-code-16-write-multiple-holding-registers.html

Not sure about the checklist below, let me know if I should do something more or feel free to add to this PR.

# Checklist

Please verify this PR includes the following if relevant:

- [ ] `siot_test` passes
- [ ] `CHANGELOG.md` entry created/updated
- [ ] [docs/](https://github.com/simpleiot/simpleiot/tree/master/docs)
      created/updated

Thanks!
