### PR TITLE
remove the unused and deprecated `multilingual` field from `book.toml`

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -3,7 +3,6 @@
 [book]
 authors = ["Cliff Brake"]
 language = "en"
-multilingual = false
 src = "."
 title = "Simple IoT"
 


### PR DESCRIPTION
See https://github.com/szabgab/public-mdbooks/issues/10