### PR TITLE
Browser client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ For more details or to discuss releases, please visit the
 
 ## [Unreleased]
 
+## [[0.18.4] - 2025-07-22](https://github.com/simpleiot/simpleiot/releases/tag/v0.18.4)
+
+- add browser client allowing control and configuration of Yoe Kiosk Browser
+
 ## [[0.18.3] - 2025-03-20](https://github.com/simpleiot/simpleiot/releases/tag/v0.18.3)
 
 - add favicon to frontend so icon displays in browser tabs (#756)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -25,6 +25,7 @@
   - [Synchronization](docs/user/sync.md)
   - [Update](docs/user/update.md)
   - [USB](docs/user/usb.md)
+  - [Browser](docs/user/browser.md)
 - [Graphing](docs/user/graphing.md)
 - [Configuration](docs/user/configuration.md)
 - [Status/Errata](docs/user/status.md)

--- a/client/browser.go
+++ b/client/browser.go
@@ -1,0 +1,583 @@
+package client
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/simpleiot/simpleiot/data"
+)
+
+const (
+	browserConfigPath = "/etc/default/yoe-kiosk-browser"
+	eglfsConfigPath   = "/etc/default/eglfs.json"
+	serviceName       = "yoe-kiosk-browser"
+)
+
+// BrowserClient is a SimpleIoT client that advertises a service via Browser and also
+// queries for neighbouring devices running the same service
+type BrowserClient struct {
+	log          *log.Logger
+	nc           *nats.Conn
+	config       Browser
+	stopCh       chan struct{}
+	pointsCh     chan NewPoints
+	edgePointsCh chan NewPoints
+}
+
+// Browser client configuration
+type Browser struct {
+	ID               string `node:"id"`
+	Parent           string `node:"parent"`
+	Description      string `point:"description"`
+	URL              string `point:"url"`
+	Disabled         bool   `point:"disabled"`
+	Rotate           int    `point:"rotate"`
+	KeyboardScale    bool   `point:"keyboardscale"`
+	Fullscreen       bool   `point:"fullscreen"`
+	DefaultDialogs   bool   `point:"defaultdialogs"`
+	DialogColor      string `point:"dialogcolor"`
+	TouchQuirk       bool   `point:"touchquirk"`
+	RetryInterval    int    `point:"retryinterval"`
+	ExceptionURL     string `point:"exceptionurl"`
+	IgnoreCertErr    bool   `point:"ignorecerterr"`
+	DisableSandbox   bool   `point:"disablesandbox"`
+	ScreenResolution string `point:"screenresolution"`
+	DisplayCard      string `point:"displaycard"`
+	DebugPort        string `point:"debugport"`
+}
+
+// BrowserConfigFile outlines the config file for Yoe Kiosk Browser
+type BrowserConfigFile struct {
+	URL            string
+	Rotate         int
+	KeyboardScale  bool
+	Fullscreen     bool
+	DefaultDialogs bool
+	DialogColor    string
+	TouchQuirk     bool
+	RetryInterval  int
+	ExceptionURL   string
+	IgnoreCertErr  bool
+	DisableSandbox bool
+	DebugPort      string
+	XAuthority     string
+	QtQpaPlatform  string
+}
+
+// EGLSFSOutputs outlintes the outputs array found in the EGLFS config file JSON
+type EGLSFSOutputs struct {
+	Name *string `json:"name"`
+	Mode *string `json:"mode"`
+}
+
+// EGLFSConfigFile outlines the JSON file containing EGLFS configuration
+type EGLFSConfigFile struct {
+	Device   *string          `json:"device"`
+	HwCursor *bool            `json:"hwcursor"`
+	Pbuffers *bool            `json:"pbuffers"`
+	Outputs  *[]EGLSFSOutputs `json:"outputs"`
+}
+
+// NewBrowserClient returns a new BrowserClient using its
+// configuration read from the Client Manager
+func NewBrowserClient(nc *nats.Conn, config Browser) Client {
+	// TODO: Ensure only one Browser client exists
+	return &BrowserClient{
+		log:      log.New(os.Stderr, "Browser: ", log.LstdFlags|log.Lmsgprefix),
+		nc:       nc,
+		config:   config,
+		stopCh:   make(chan struct{}),
+		pointsCh: make(chan NewPoints),
+	}
+}
+
+// reads the configuration from disk
+func readEGLFSConfig() (*EGLFSConfigFile, error) {
+	file, err := os.Open(eglfsConfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open file %s with error: %w", eglfsConfigPath, err)
+	}
+	defer file.Close()
+
+	var config EGLFSConfigFile
+	decoder := json.NewDecoder(file)
+	if err := decoder.Decode(&config); err != nil {
+		return nil, fmt.Errorf("failed to decode %s with error: %w", eglfsConfigPath, err)
+	}
+
+	return &config, nil
+}
+
+// update the json file on disk with provided key/value pair
+func updateEGLFSConfigInPlace(key, value string) error {
+	config, err := readEGLFSConfig()
+	if err != nil {
+		return fmt.Errorf("failed to read EGLFS config: %w", err)
+	}
+
+	switch key {
+	case "display-card":
+		config.Device = &value
+	case "resolution":
+		// Update the first output's mode (resolution)
+		if len(*config.Outputs) > 0 {
+			(*config.Outputs)[0].Mode = &value
+		} else {
+			// If no outputs exist, create one with default name
+			name := "LVDS-1"
+			config.Outputs = &[]EGLSFSOutputs{
+				{Name: &name, Mode: &value},
+			}
+		}
+	default:
+		return fmt.Errorf("unknown EGLFS configuration key: %s", key)
+	}
+
+	file, err := os.Create(eglfsConfigPath)
+	if err != nil {
+		return fmt.Errorf("failed to create EGLFS config file: %w", err)
+	}
+	defer file.Close()
+
+	encoder := json.NewEncoder(file)
+	encoder.SetIndent("", "  ") // Pretty print with 2-space indentation
+	if err := encoder.Encode(config); err != nil {
+		return fmt.Errorf("failed to encode EGLFS JSON: %w", err)
+	}
+
+	return nil
+}
+
+// read the current configuration from disk
+func readBrowserConfig(file io.Reader) (*BrowserConfigFile, error) {
+	config := &BrowserConfigFile{}
+	scanner := bufio.NewScanner(file)
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+
+		key := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+
+		switch key {
+		case "YOE_KIOSK_BROWSER_URL":
+			config.URL = value
+		case "YOE_KIOSK_BROWSER_ROTATE":
+			val, _ := strconv.Atoi(value)
+			config.Rotate = val
+		case "YOE_KIOSK_BROWSER_KEYBOARD_SCALE":
+			val, _ := strconv.ParseBool(value)
+			config.KeyboardScale = val
+		case "YOE_KIOSK_BROWSER_FULLSCREEN":
+			val, _ := strconv.ParseBool(value)
+			config.Fullscreen = val
+		case "YOE_KIOSK_BROWSER_DEFAULT_DIALOGS":
+			val, _ := strconv.ParseBool(value)
+			config.DefaultDialogs = val
+		case "YOE_KIOSK_BROWSER_DIALOG_COLOR":
+			config.DialogColor = value
+		case "YOE_KIOSK_BROWSER_TOUCH_QUIRK":
+			val, _ := strconv.ParseBool(value)
+			config.TouchQuirk = val
+		case "YOE_KIOSK_BROWSER_RETRY_INTERVAL":
+			val, _ := strconv.Atoi(value)
+			config.RetryInterval = val
+		case "YOE_KIOSK_BROWSER_EXCEPTION_URL":
+			config.ExceptionURL = value
+		case "YOE_KIOSK_BROWSER_IGNORE_CERT_ERR":
+			val, _ := strconv.ParseBool(value)
+			config.IgnoreCertErr = val
+		case "QTWEBENGINE_DISABLE_SANDBOX":
+			val, _ := strconv.ParseBool(value)
+			config.DisableSandbox = val
+		case "QTWEBENGINE_REMOTE_DEBUGGING":
+			config.DebugPort = value
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("error reading %s file: %w", browserConfigPath, err)
+	}
+
+	return config, nil
+}
+
+// update the file on disk with provided key/value pair
+func updateConfigInPlace(key, value string) error {
+	// Map user-friendly keys to actual environment variable names
+	keyMap := map[string]string{
+		"url":             "YOE_KIOSK_BROWSER_URL",
+		"rotate":          "YOE_KIOSK_BROWSER_ROTATE",
+		"keyboard-scale":  "YOE_KIOSK_BROWSER_KEYBOARD_SCALE",
+		"fullscreen":      "YOE_KIOSK_BROWSER_FULLSCREEN",
+		"default-dialogs": "YOE_KIOSK_BROWSER_DEFAULT_DIALOGS",
+		"dialog-color":    "YOE_KIOSK_BROWSER_DIALOG_COLOR",
+		"touch-quirk":     "YOE_KIOSK_BROWSER_TOUCH_QUIRK",
+		"retry-interval":  "YOE_KIOSK_BROWSER_RETRY_INTERVAL",
+		"exception-url":   "YOE_KIOSK_BROWSER_EXCEPTION_URL",
+		"ignore-cert-err": "YOE_KIOSK_BROWSER_IGNORE_CERT_ERR",
+		"disable-sandbox": "QTWEBENGINE_DISABLE_SANDBOX",
+		"debug-port":      "QTWEBENGINE_REMOTE_DEBUGGING",
+		"xauthority":      "XAUTHORITY",
+		"qt-qpa-platform": "QT_QPA_PLATFORM",
+	}
+
+	actualKey, exists := keyMap[key]
+	if !exists {
+		return fmt.Errorf("unknown configuration key: %s", key)
+	}
+
+	// Read the entire file
+	file, err := os.Open(browserConfigPath)
+	if err != nil {
+		return fmt.Errorf("failed to open config file: %w", err)
+	}
+	defer file.Close()
+
+	var lines []string
+	scanner := bufio.NewScanner(file)
+	keyFound := false
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// Check if this line contains the key we want to modify
+		if strings.Contains(line, "=") {
+			parts := strings.SplitN(line, "=", 2)
+			if len(parts) == 2 {
+				lineKey := strings.TrimSpace(parts[0])
+				if lineKey == actualKey {
+					// Replace the value while preserving any formatting
+					lines = append(lines, fmt.Sprintf("%s=%s", actualKey, value))
+					keyFound = true
+					continue
+				}
+			}
+		}
+
+		// Keep the original line if it's not the key we're modifying
+		lines = append(lines, line)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("error reading config file: %w", err)
+	}
+
+	// If the key wasn't found, append it to the end
+	if !keyFound {
+		lines = append(lines, fmt.Sprintf("%s=%s", actualKey, value))
+	}
+
+	file, err = os.Create(browserConfigPath)
+	if err != nil {
+		return fmt.Errorf("failed to create config file: %w", err)
+	}
+	defer file.Close()
+
+	writer := bufio.NewWriter(file)
+	defer writer.Flush()
+
+	for _, line := range lines {
+		fmt.Fprintln(writer, line)
+	}
+
+	return nil
+}
+
+func restartService(serviceName string) error {
+	return exec.Command("/usr/bin/systemctl", "restart", serviceName).Run()
+}
+
+func disableService(serviceName string) error {
+	return exec.Command("/usr/bin/systemctl", "disable", serviceName).Run()
+}
+
+func enableService(serviceName string) error {
+	return exec.Command("/usr/bin/systemctl", "enable", serviceName).Run()
+}
+
+// Run starts the Browser Client
+func (c *BrowserClient) Run() error {
+	str := "Starting Browser client"
+	if c.config.Disabled {
+		str += " (currently disabled)"
+	}
+	c.log.Println(str)
+
+	init := func() error {
+
+		file, err := os.Open(browserConfigPath)
+		if err != nil {
+			return fmt.Errorf("failed to open %s with error: %w", browserConfigPath, err)
+		}
+		defer file.Close()
+
+		browserConfig, err := readBrowserConfig(file)
+		if err != nil {
+			return err
+		}
+
+		c.config.URL = browserConfig.URL
+		c.config.Rotate = browserConfig.Rotate
+		c.config.KeyboardScale = browserConfig.KeyboardScale
+		c.config.Fullscreen = browserConfig.Fullscreen
+		c.config.DefaultDialogs = browserConfig.DefaultDialogs
+		c.config.DialogColor = browserConfig.DialogColor
+		c.config.TouchQuirk = browserConfig.TouchQuirk
+		c.config.RetryInterval = browserConfig.RetryInterval
+		c.config.ExceptionURL = browserConfig.ExceptionURL
+		c.config.IgnoreCertErr = browserConfig.IgnoreCertErr
+		c.config.DisableSandbox = browserConfig.DisableSandbox
+
+		eglfsConfig, err := readEGLFSConfig()
+		if err != nil {
+			return err
+		}
+
+		if eglfsConfig.Device != nil {
+			c.config.DisplayCard = *eglfsConfig.Device
+		}
+		if eglfsConfig.Outputs != nil && (*eglfsConfig.Outputs)[0].Mode != nil {
+			c.config.ScreenResolution = *(*eglfsConfig.Outputs)[0].Mode
+		}
+		c.ValidatePoints()
+
+		return nil
+	}
+
+	err := init()
+	if err != nil {
+		c.log.Println("init returned with", err)
+		return err
+	}
+
+loop:
+	for {
+		select {
+		case <-c.stopCh:
+			log.Println("Stopping Browser client:", c.config.Description)
+			break loop
+
+		case pts := <-c.pointsCh:
+			log.Println("Received point - ", pts)
+
+			err := data.MergePoints(pts.ID, pts.Points, &c.config)
+			if err != nil {
+				log.Println("error merging new points:", err)
+			}
+
+			c.ValidatePoints()
+
+			// Update the configuration in place
+
+			if err := updateConfigInPlace("url", c.config.URL); err != nil {
+				c.log.Printf("Error updating config: %v", err)
+			}
+			if err := updateConfigInPlace("rotate", strconv.Itoa(c.config.Rotate)); err != nil {
+				c.log.Printf("Error updating config: %v", err)
+			}
+			if err := updateConfigInPlace("keyboard-scale", boolToIntString(c.config.KeyboardScale)); err != nil {
+				c.log.Printf("Error updating config: %v", err)
+			}
+			if err := updateConfigInPlace("fullscreen", boolToIntString(c.config.Fullscreen)); err != nil {
+				c.log.Printf("Error updating config: %v", err)
+			}
+			if err := updateConfigInPlace("default-dialogs", boolToIntString(c.config.DefaultDialogs)); err != nil {
+				c.log.Printf("Error updating config: %v", err)
+			}
+			if err := updateConfigInPlace("dialog-color", c.config.DialogColor); err != nil {
+				c.log.Printf("Error updating config: %v", err)
+			}
+			if err := updateConfigInPlace("touch-quirk", boolToIntString(c.config.TouchQuirk)); err != nil {
+				c.log.Printf("Error updating config: %v", err)
+			}
+			if err := updateConfigInPlace("retry-interval", strconv.Itoa(c.config.RetryInterval)); err != nil {
+				c.log.Printf("Error updating config: %v", err)
+			}
+			if err := updateConfigInPlace("exception-url", c.config.ExceptionURL); err != nil {
+				c.log.Printf("Error updating config: %v", err)
+			}
+			if err := updateConfigInPlace("ignore-cert-err", boolToIntString(c.config.IgnoreCertErr)); err != nil {
+				c.log.Printf("Error updating config: %v", err)
+			}
+			if err := updateConfigInPlace("disable-sandbox", boolToIntString(c.config.DisableSandbox)); err != nil {
+				c.log.Printf("Error updating config: %v", err)
+			}
+			if err := updateConfigInPlace("debug-port", c.config.DebugPort); err != nil {
+				c.log.Printf("Error updating config: %v", err)
+			}
+			if err := updateEGLFSConfigInPlace("display-card", c.config.DisplayCard); err != nil {
+				c.log.Printf("Error updating config: %v", err)
+			}
+			if err := updateEGLFSConfigInPlace("resolution", c.config.ScreenResolution); err != nil {
+				c.log.Printf("Error updating config: %v", err)
+			}
+
+			if c.config.Disabled {
+				err = disableService(serviceName)
+				if err != nil {
+					c.log.Println("Error disabling service ", serviceName)
+				}
+			} else {
+				err = enableService(serviceName)
+				if err != nil {
+					c.log.Println("Error enabling service ", serviceName)
+				}
+				err = restartService(serviceName)
+				if err != nil {
+					c.log.Println("Error restarting service ", serviceName)
+				}
+			}
+
+		case pts := <-c.edgePointsCh:
+			err := data.MergeEdgePoints(pts.ID, pts.Parent, pts.Points, &c.config)
+			if err != nil {
+				log.Println("error merging new points:", err)
+			}
+		}
+	}
+	return nil
+}
+
+// ValidatePoints sets points to their default state if unset.
+func (c *BrowserClient) ValidatePoints() {
+	validateString := func(value string, fallback string, nc *nats.Conn, ID string, pointType string) (string, error) {
+		val := value
+		if val == "" {
+			val = fallback
+		}
+		c.log.Printf("Setting %s to: %s", pointType, val)
+		err := SendNodePoint(nc, ID, data.Point{
+			Time: time.Now(),
+			Type: pointType,
+			Key:  "0",
+			Text: val}, false)
+		if err != nil {
+			c.log.Println("Error sending point: ", err)
+			return val, err
+		}
+		return val, nil
+	}
+
+	validateInt := func(value int, fallback int, nc *nats.Conn, ID string, pointType string) (int, error) {
+		val := value
+		if val < 0 {
+			val = fallback
+		}
+		c.log.Printf("Setting %s to: %d", pointType, val)
+		err := SendNodePoint(nc, ID, data.Point{
+			Time:  time.Now(),
+			Type:  pointType,
+			Key:   "0",
+			Value: float64(val)}, false)
+		if err != nil {
+			c.log.Println("Error sending point: ", err)
+			return val, err
+		}
+		return val, nil
+	}
+
+	validateBool := func(value bool, nc *nats.Conn, ID string, pointType string) (bool, error) {
+		c.log.Printf("Setting %s to: %t", pointType, value)
+		err := SendNodePoint(nc, ID, data.Point{
+			Time:  time.Now(),
+			Type:  pointType,
+			Key:   "0",
+			Value: data.BoolToFloat(value)}, false)
+		if err != nil {
+			c.log.Println("Error sending point: ", err)
+			return value, err
+		}
+		return value, nil
+	}
+
+	defaults := struct {
+		URL              string
+		Disabled         bool
+		Rotate           int
+		DefaultDialogs   bool
+		DialogColor      string
+		TouchQuirk       bool
+		RetryInterval    int
+		ExceptionURL     string
+		IgnoreCertErr    bool
+		DisableSandbox   bool
+		DebugPort        string
+		ScreenResolution string
+		DisplayCard      string
+	}{
+		"http://localhost:8080",
+		false,
+		0,
+		false,
+		"#D91824",
+		true,
+		10,
+		"",
+		true,
+		true,
+		"",
+		"1024x600",
+		"/dev/dri/card0",
+	}
+
+	c.config.URL, _ = validateString(c.config.URL, defaults.URL, c.nc, c.config.ID, data.PointTypeURL)
+	c.config.Disabled, _ = validateBool(c.config.Disabled, c.nc, c.config.ID, data.PointTypeDisabled)
+	c.config.Rotate, _ = validateInt(c.config.Rotate, defaults.Rotate, c.nc, c.config.ID, data.PointTypeRotate)
+	c.config.KeyboardScale, _ = validateBool(c.config.KeyboardScale, c.nc, c.config.ID, data.PointTypeKeyboardScale)
+	c.config.Fullscreen, _ = validateBool(c.config.Fullscreen, c.nc, c.config.ID, data.PointTypeFullscreen)
+	c.config.DefaultDialogs, _ = validateBool(c.config.DefaultDialogs, c.nc, c.config.ID, data.PointTypeDefaultDialogs)
+	c.config.TouchQuirk, _ = validateBool(c.config.TouchQuirk, c.nc, c.config.ID, data.PointTypeTouchQuirk)
+	c.config.IgnoreCertErr, _ = validateBool(c.config.IgnoreCertErr, c.nc, c.config.ID, data.PointTypeIgnoreCertErr)
+	c.config.DisableSandbox, _ = validateBool(c.config.DisableSandbox, c.nc, c.config.ID, data.PointTypeDisableSandbox)
+	c.config.URL, _ = validateString(c.config.URL, defaults.URL, c.nc, c.config.ID, data.PointTypeURL)
+	c.config.DialogColor, _ = validateString(c.config.DialogColor, defaults.DialogColor, c.nc, c.config.ID, data.PointTypeDialogColor)
+	c.config.RetryInterval, _ = validateInt(c.config.RetryInterval, defaults.RetryInterval, c.nc, c.config.ID, data.PointTypeRetryInterval)
+	c.config.ExceptionURL, _ = validateString(c.config.ExceptionURL, defaults.ExceptionURL, c.nc, c.config.ID, data.PointTypeExceptionURL)
+	c.config.DebugPort, _ = validateString(c.config.DebugPort, defaults.DebugPort, c.nc, c.config.ID, data.PointTypeDebugPort)
+	c.config.ScreenResolution, _ = validateString(c.config.ScreenResolution, defaults.ScreenResolution, c.nc, c.config.ID, data.PointTypeScreenResolution)
+	c.config.DisplayCard, _ = validateString(c.config.DisplayCard, defaults.DisplayCard, c.nc, c.config.ID, data.PointTypeDisplayCard)
+}
+
+func boolToIntString(b bool) string {
+	if b {
+		return "1"
+	}
+	return "0"
+}
+
+// Stop stops the Browser Client
+func (c *BrowserClient) Stop(error) {
+	close(c.stopCh)
+}
+
+// Points is called when the client's node points are updated
+func (c *BrowserClient) Points(nodeID string, points []data.Point) {
+	c.pointsCh <- NewPoints{
+		ID:     nodeID,
+		Points: points,
+	}
+}
+
+// EdgePoints is called by the Manager when new edge points for this
+// node are received.
+func (c *BrowserClient) EdgePoints(nodeID, parentID string, points []data.Point) {
+	c.edgePointsCh <- NewPoints{nodeID, parentID, points}
+}

--- a/client/browser_test.go
+++ b/client/browser_test.go
@@ -1,0 +1,92 @@
+package client
+
+import (
+	"bytes"
+	"strconv"
+	"testing"
+)
+
+// Does not err on empty file
+func TestReadBrowserConfigEmptyFile(t *testing.T) {
+	contents := ""
+	file := bytes.NewBufferString(contents)
+
+	_, err := readBrowserConfig(file)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+// Correctly assigns vars
+func TestReadBrowserConfigValidFile(t *testing.T) {
+	browserURL := "http://localhost:8118"
+	rotate := 180
+	keyboardScale := true
+	fullscreen := true
+	defaultDialogs := true
+	dialogColor := "#FF0000"
+	touchQuirk := true
+	retryInterval := 20
+	exceptionURL := "http://exception-url"
+	ignoreCertErr := true
+	disableSandbox := true
+	remoteDebugging := "0.0.0.0:9222"
+	contents := `
+				YOE_KIOSK_BROWSER_URL=` + browserURL + `
+				YOE_KIOSK_BROWSER_ROTATE=` + strconv.Itoa(rotate) + `
+				YOE_KIOSK_BROWSER_KEYBOARD_SCALE=` + boolToIntString(keyboardScale) + `
+				YOE_KIOSK_BROWSER_FULLSCREEN=` + boolToIntString(fullscreen) + `
+				YOE_KIOSK_BROWSER_DEFAULT_DIALOGS=` + boolToIntString(defaultDialogs) + `
+				YOE_KIOSK_BROWSER_DIALOG_COLOR=` + dialogColor + `
+				YOE_KIOSK_BROWSER_TOUCH_QUIRK=` + boolToIntString(touchQuirk) + `
+				YOE_KIOSK_BROWSER_RETRY_INTERVAL=` + strconv.Itoa(retryInterval) + `
+				YOE_KIOSK_BROWSER_EXCEPTION_URL=` + exceptionURL + `
+				YOE_KIOSK_BROWSER_IGNORE_CERT_ERR=` + boolToIntString(ignoreCertErr) + `
+				QTWEBENGINE_DISABLE_SANDBOX=` + boolToIntString(disableSandbox) + `
+				QTWEBENGINE_REMOTE_DEBUGGING=` + remoteDebugging + `
+				`
+	file := bytes.NewBufferString(contents)
+
+	config, err := readBrowserConfig(file)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if config.URL != browserURL {
+		t.Error("Failed to read YOE_KIOSK_BROWSER_URL")
+	}
+	if config.Rotate != rotate {
+		t.Error("Failed to read YOE_KIOSK_BROWSER_ROTATE")
+	}
+	if config.KeyboardScale != keyboardScale {
+		t.Error("Failed to read YOE_KIOSK_BROWSER_KEYBOARD_SCALE")
+	}
+	if config.Fullscreen != fullscreen {
+		t.Error("Failed to read YOE_KIOSK_BROWSER_FULLSCREEN")
+	}
+	if config.DefaultDialogs != defaultDialogs {
+		t.Error("Failed to read YOE_KIOSK_BROWSER_DEFAULT_DIALOGS")
+	}
+	if config.DialogColor != dialogColor {
+		t.Error("Failed to read YOE_KIOSK_BROWSER_DIALOG_COLOR")
+	}
+	if config.TouchQuirk != touchQuirk {
+		t.Error("Failed to read YOE_KIOSK_BROWSER_TOUCH_QUIRK")
+	}
+	if config.RetryInterval != retryInterval {
+		t.Error("Failed to read YOE_KIOSK_BROWSER_RETRY_INTERVAL")
+	}
+	if config.ExceptionURL != exceptionURL {
+		t.Error("Failed to read YOE_KIOSK_BROWSER_EXCEPTION_URL")
+	}
+	if config.IgnoreCertErr != ignoreCertErr {
+		t.Error("Failed to read YOE_KIOSK_BROWSER_IGNORE_CERT_ERR")
+	}
+	if config.DisableSandbox != disableSandbox {
+		t.Error("Failed to read QTWEBENGINE_DISABLE_SANDBOX")
+	}
+	if config.DebugPort != remoteDebugging {
+		t.Error("Failed to read QTWEBENGINE_REMOTE_DEBUGGING")
+	}
+}

--- a/client/client.go
+++ b/client/client.go
@@ -60,6 +60,9 @@ func DefaultClients(nc *nats.Conn) (*RunGroup, error) {
 	ntp := NewManager(nc, NewNTPClient, nil)
 	g.Add(ntp)
 
+	browser := NewManager(nc, NewBrowserClient, nil)
+	g.Add(browser)
+
 	nm := NewManager(nc, NewNetworkManagerClient, nil)
 	g.Add(nm)
 

--- a/data/schema.go
+++ b/data/schema.go
@@ -232,6 +232,22 @@ const (
 	PointTypeMsgsRecvdOther      = "msgsRecvdOther"
 	PointTypeMsgsRecvdOtherReset = "msgsRecvdOtherReset"
 
+	// Browser
+	PointTypeURL              = "url"
+	PointTypeRotate           = "rotate"
+	PointTypeKeyboardScale    = "keyboardscale"
+	PointTypeFullscreen       = "fullscreen"
+	PointTypeDefaultDialogs   = "defaultdialogs"
+	PointTypeDialogColor      = "dialogcolor"
+	PointTypeTouchQuirk       = "touchquirk"
+	PointTypeRetryInterval    = "retryinterval"
+	PointTypeExceptionURL     = "exceptionurl"
+	PointTypeIgnoreCertErr    = "ignorecerterr"
+	PointTypeDisableSandbox   = "disablesandbox"
+	PointTypeDebugPort        = "debugport"
+	PointTypeScreenResolution = "screenresolution"
+	PointTypeDisplayCard      = "displaycard"
+
 	NodeTypeSignalGenerator = "signalGenerator"
 
 	PointTypeSignalType   = "signalType"

--- a/docs/user/browser.md
+++ b/docs/user/browser.md
@@ -1,0 +1,8 @@
+# Browser
+
+The browser client enables control and configuration of the
+[Yoe Kiosk Browser](https://github.com/YoeDistro/yoe-kiosk-browser) as it is 
+when installed as part of Yoe Distro. On changing the configuration, changes 
+are saved to `/etc/default/yoe-kiosk-browser` for the browser and 
+`/etc/default/eglfs.json` for EGLFS, and the `yoe-kiosk-browser` service is 
+restarted automatically.

--- a/frontend/src/Api/Node.elm
+++ b/frontend/src/Api/Node.elm
@@ -13,6 +13,7 @@ module Api.Node exposing
     , postPoints
     , typeAction
     , typeActionInactive
+    , typeBrowser
     , typeCanBus
     , typeCondition
     , typeDb
@@ -178,6 +179,11 @@ typeNetworkManagerConn =
 typeNTP : String
 typeNTP =
     "ntp"
+
+
+typeBrowser : String
+typeBrowser =
+    "browser"
 
 
 typeUpdate : String

--- a/frontend/src/Api/Point.elm
+++ b/frontend/src/Api/Point.elm
@@ -46,13 +46,18 @@ module Api.Point exposing
     , typeDataFormat
     , typeDate
     , typeDebug
+    , typeDebugPort
+    , typeDefaultDialogs
     , typeDescription
     , typeDestination
     , typeDevice
     , typeDeviceID
+    , typeDialogColor
     , typeDirectory
+    , typeDisableSandbox
     , typeDisabled
     , typeDiscardDownload
+    , typeDisplayCard
     , typeDownload
     , typeDownloadOS
     , typeEmail
@@ -66,19 +71,23 @@ module Api.Point exposing
     , typeErrorCountHR
     , typeErrorCountReset
     , typeErrorCountResetHR
+    , typeExceptionURL
     , typeFallbackServer
     , typeFilePath
     , typeFirstName
     , typeFrequency
     , typeFrom
+    , typeFullscreen
     , typeHRDest
     , typeHash
     , typeHrRx
     , typeHrRxReset
     , typeID
     , typeIP
+    , typeIgnoreCertErr
     , typeIndex
     , typeInitialValue
+    , typeKeyboardScale
     , typeLastName
     , typeLightSet
     , typeLog
@@ -117,12 +126,15 @@ module Api.Point exposing
     , typeReadOnly
     , typeReboot
     , typeRefresh
+    , typeRetryInterval
+    , typeRotate
     , typeRoundTo
     , typeRx
     , typeRxReset
     , typeSID
     , typeSampleRate
     , typeScale
+    , typeScreenResolution
     , typeServer
     , typeService
     , typeSignalType
@@ -137,10 +149,12 @@ module Api.Point exposing
     , typeTag
     , typeTagPointType
     , typeTombstone
+    , typeTouchQuirk
     , typeTx
     , typeTxReset
     , typeType
     , typeURI
+    , typeURL
     , typeUnits
     , typeValue
     , typeValueSet
@@ -678,6 +692,76 @@ valueSetValue =
 valuePlayAudio : String
 valuePlayAudio =
     "playAudio"
+
+
+typeURL : String
+typeURL =
+    "url"
+
+
+typeRotate : String
+typeRotate =
+    "rotate"
+
+
+typeKeyboardScale : String
+typeKeyboardScale =
+    "keyboardscale"
+
+
+typeFullscreen : String
+typeFullscreen =
+    "fullscreen"
+
+
+typeDefaultDialogs : String
+typeDefaultDialogs =
+    "defaultdialogs"
+
+
+typeDialogColor : String
+typeDialogColor =
+    "dialogcolor"
+
+
+typeTouchQuirk : String
+typeTouchQuirk =
+    "touchquirk"
+
+
+typeRetryInterval : String
+typeRetryInterval =
+    "retryinterval"
+
+
+typeExceptionURL : String
+typeExceptionURL =
+    "exceptionurl"
+
+
+typeIgnoreCertErr : String
+typeIgnoreCertErr =
+    "ignorecerterr"
+
+
+typeDisableSandbox : String
+typeDisableSandbox =
+    "disablesandbox"
+
+
+typeDebugPort : String
+typeDebugPort =
+    "debugport"
+
+
+typeScreenResolution : String
+typeScreenResolution =
+    "screenresolution"
+
+
+typeDisplayCard : String
+typeDisplayCard =
+    "displaycard"
 
 
 typeService : String

--- a/frontend/src/Components/NodeBrowser.elm
+++ b/frontend/src/Components/NodeBrowser.elm
@@ -1,0 +1,62 @@
+module Components.NodeBrowser exposing (view)
+
+import Api.Point as Point
+import Components.NodeOptions exposing (NodeOptions, oToInputO)
+import Element exposing (..)
+import Element.Border as Border
+import UI.Icon as Icon
+import UI.NodeInputs as NodeInputs
+import UI.Style as Style
+
+
+view : NodeOptions msg -> Element msg
+view o =
+    column
+        [ width fill
+        , Border.widthEach { top = 2, bottom = 0, left = 0, right = 0 }
+        , Border.color Style.colors.black
+        , spacing 6
+        ]
+    <|
+        wrappedRow [ spacing 10 ]
+            [ Icon.globe
+            , text <|
+                Point.getText o.node.points Point.typeDescription ""
+            ]
+            :: (if o.expDetail then
+                    let
+                        labelWidth =
+                            150
+
+                        opts =
+                            oToInputO o labelWidth
+
+                        textInput =
+                            NodeInputs.nodeTextInput opts "0"
+
+                        numberInput =
+                            NodeInputs.nodeNumberInput opts "0"
+
+                        boolInput =
+                            NodeInputs.nodeCheckboxInput opts "0"
+                    in
+                    [ textInput Point.typeURL "URL" ""
+                    , boolInput Point.typeDisabled "Disabled"
+                    , numberInput Point.typeRotate "Rotate"
+                    , boolInput Point.typeKeyboardScale "Keyboard Scale"
+                    , boolInput Point.typeFullscreen "Fullscreen"
+                    , boolInput Point.typeDefaultDialogs "Default Dialogs"
+                    , textInput Point.typeDialogColor "Dialog Color" ""
+                    , boolInput Point.typeTouchQuirk "Touch Quirk"
+                    , numberInput Point.typeRetryInterval "Retry Interval"
+                    , textInput Point.typeExceptionURL "Exception URL" ""
+                    , boolInput Point.typeIgnoreCertErr "Ignore Cert Error"
+                    , boolInput Point.typeDisableSandbox "Disable Sandbox"
+                    , textInput Point.typeDebugPort "Debug Port" ""
+                    , textInput Point.typeScreenResolution "Screen Resolution" ""
+                    , textInput Point.typeDisplayCard "Display Card" ""
+                    ]
+
+                else
+                    []
+               )

--- a/frontend/src/Pages/Home_.elm
+++ b/frontend/src/Pages/Home_.elm
@@ -8,6 +8,7 @@ import Api.Response exposing (Response)
 import Auth
 import Base64.Encode
 import Components.NodeAction as NodeAction
+import Components.NodeBrowser as NodeBrowser
 import Components.NodeCanBus as NodeCanBus
 import Components.NodeCondition as NodeCondition
 import Components.NodeDb as NodeDb
@@ -1049,6 +1050,7 @@ nodeCustomSortRules =
         , ( Node.typeNetworkManager, "R" )
         , ( Node.typeNTP, "S" )
         , ( Node.typeUpdate, "T" )
+        , ( Node.typeBrowser, "U" )
 
         -- rule subnodes
         , ( Node.typeCondition, "A" )
@@ -1332,6 +1334,9 @@ viewNode model parent node children depth =
 
                     "ntp" ->
                         NodeNTP.view
+
+                    "browser" ->
+                        NodeBrowser.view
 
                     "networkManagerDevice" ->
                         NodeNetworkManagerDevice.view
@@ -1656,6 +1661,11 @@ nodeDescNTP =
     row [] [ Icon.clock, text "NTP" ]
 
 
+nodeDescBrowser : Element Msg
+nodeDescBrowser =
+    row [] [ Icon.globe, text "Browser" ]
+
+
 viewAddNode : String -> NodeView -> NodeToAdd -> Element Msg
 viewAddNode customNodeType parent add =
     column [ spacing 10 ]
@@ -1670,6 +1680,7 @@ viewAddNode customNodeType parent add =
                     , Input.option Node.typeRule nodeDescRule
                     , Input.option Node.typeNetworkManager nodeDescNetworkManager
                     , Input.option Node.typeNTP nodeDescNTP
+                    , Input.option Node.typeBrowser nodeDescBrowser
                     , Input.option Node.typeModbus nodeDescModbus
                     , Input.option Node.typeSerialDev nodeDescSerialDev
                     , Input.option Node.typeCanBus nodeDescCanBus

--- a/frontend/src/UI/Icon.elm
+++ b/frontend/src/UI/Icon.elm
@@ -12,6 +12,7 @@ module UI.Icon exposing
     , database
     , device
     , file
+    , globe
     , io
     , list
     , network
@@ -266,3 +267,7 @@ clock =
 update : Element msg
 update =
     icon FeatherIcons.refreshCw
+
+globe : Element msg
+globe =
+    icon FeatherIcons.globe


### PR DESCRIPTION
Allows control of Yoe Kiosk Browser from the Simple IOT portal.

[
<img width="1044" height="1562" alt="Screenshot 2025-07-22 at 00 32 06" src="https://github.com/user-attachments/assets/dbe5c8dc-bac5-4606-9d6b-cbde1e97c8cc" />
](url)

# Checklist
- [ ] `siot_test` passes
- [x] `CHANGELOG.md` entry created/updated
- [x] [docs/](https://github.com/simpleiot/simpleiot/tree/master/docs)
      created/updated

`siot_test` fails for me on `golangci-lint run` for already included packages. No errors are shown for additions in this PR though.